### PR TITLE
Use cargo binstall in setup scripts

### DIFF
--- a/packages/scripts/setup.ps1
+++ b/packages/scripts/setup.ps1
@@ -198,8 +198,7 @@ https://learn.microsoft.com/windows/package-manager/winget/
 
     Write-Host
     Write-Host 'Installing Rust tools...' -ForegroundColor Yellow
-    cargo install cargo-watch
-	cargo install sqlx-cli
+    if (Get-Command cargo-binstall -ea 0) { cargo binstall cargo-watch sqlx-cli } else { cargo install cargo-watch sqlx-cli }
     if ($LASTEXITCODE -ne 0) {
         Exit-WithError 'Failed to install Rust tools'
     }

--- a/packages/scripts/setup.sh
+++ b/packages/scripts/setup.sh
@@ -184,7 +184,7 @@ esac
 if [ "${CI:-}" != "true" ]; then
 	echo "installing rust tools..."
 	_tools="cargo-watch sqlx-cli"
-	echo "$_tools" | xargs cargo install
+	echo "$_tools" | xargs cargo $(has cargo-binstall && echo binstall || echo install)
 fi
 
 echo 'your machine has been setup for onelauncher development!'


### PR DESCRIPTION
## Description

Checks for and uses `cargo binstall` in the setup scripts cus I was complaining about it earlier. I'm not on windows so i cant test the powershell script but like it *should* work.

## Related Issue(s)

n/a

## How to test

run the script for the respective platform

## Documentation

n/a
