### PR TITLE
fix: allow UNIX systems to look for Java in $PATH

### DIFF
--- a/packages/core/src/api/java/mod.rs
+++ b/packages/core/src/api/java/mod.rs
@@ -201,16 +201,11 @@ fn find_java_in_path(mut found: Vec<PathBuf>) -> Vec<PathBuf> {
         for path_entry in path.split(':') {
             let java = PathBuf::from(path_entry).join("java");
             if java.exists() {
-                if let Some(bin_dir) = java.parent() {
-                    if let Some(java_home) = bin_dir.parent() {
-                        let java_home_path = java_home.to_path_buf();
-                        // java executable should always be under bin/java of root
-                        let java_path = java_home_path.join("bin").join("java");
-                        if !found.contains(&java_path) {
-                            found.push(java_path);
-                        }
-                    }
-                }
+				if java.is_file() {
+					if !found.contains(&java) {
+						found.push(java);
+					}
+				}
             }
         }
     }
@@ -321,7 +316,7 @@ fn internal_locate_java() -> Vec<PathBuf> {
 	}
 
 
-	find_java_in_path(found);
+	found = find_java_in_path(found);
 
 	found
 }
@@ -359,7 +354,7 @@ fn internal_locate_java() -> Vec<PathBuf> {
 
 	// check env vars
 	// woowoooo mutation
-	let found = find_java_in_path(found);
+	found = find_java_in_path(found);
 
 	found
 }

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(let_chains)]
 #![feature(slice_as_array)]
 
 use api::proxy::LauncherProxy;


### PR DESCRIPTION
## Description

This PR is aimed at fixing the issues brought up in #343. It also removes some unused imports in mod.rs, and silences a compiler warning from lib.rs because an experimental feature flag we were using (let_chains) is no longer experimental as of version 1.88.
## Related Issue(s)

Fixes #343 

## How to test

On Linux/Mac OSX:

- Install dependencies/Setup dev environment
- Install Java to a directory other than the ones hardcoded in mod.rs
- Add that Java to $PATH environment variable
- Run `cargo run --example locate_java`

On Windows:

- uhhh idk use WSL and follow the instructions for Linux?

I haven't tested this on Mac/OSX because I do not have a MacBook, but I have tested on Debian Linux.