### PR TITLE
Feat: Small animations on recent card hover

### DIFF
--- a/apps/oneclient/frontend/src/bindings.gen.ts
+++ b/apps/oneclient/frontend/src/bindings.gen.ts
@@ -232,10 +232,8 @@ export type VersionType =
  */
 "old_beta"
 
-const ARGS_MAP = { 'core':'{"writeSettings":["setting"],"getUsers":[],"createCluster":["options"],"openMsaLogin":[],"searchPackages":["provider","query"],"killProcess":["pid"],"getGameVersions":[],"open":["input"],"getWorlds":["id"],"launchCluster":["id","uuid"],"removeUser":["uuid"],"isClusterRunning":["cluster_id"],"getPackage":["provider","slug"],"getDefaultUser":["fallback"],"getRunningProcessesByClusterId":["cluster_id"],"getClusterById":["id"],"getMultiplePackages":["provider","slugs"],"readSettings":[],"fetchMinecraftProfile":["uuid"],"getLoadersForVersion":["mc_version"],"setDefaultUser":["uuid"],"getUsersFromAuthor":["provider","author"],"getScreenshots":["id"],"getLogByName":["id","name"],"updateClusterById":["id","request"],"getGlobalProfile":[],"getUser":["uuid"],"updateClusterProfile":["name","profile"],"getPackageBody":["provider","body"],"getPackageVersions":["provider","slug","mc_version","loader","offset","limit"],"removeCluster":["id"],"downloadPackage":["provider","package_id","version_id","cluster_id","skip_compatibility"],"getProfileOrDefault":["name"],"getLogs":["id"],"getClusters":[],"getRunningProcesses":[]}', 'events':'{"ingress":["event"],"message":["event"],"process":["event"]}', 'folders':'{"openCluster":["folder_name"],"fromCluster":["folder_name"]}', 'oneclient':'{"openDevTools":[],"getClustersGroupedByMajor":[]}' }
-export type Router = { 'oneclient': { openDevTools: () => Promise<void>, 
-getClustersGroupedByMajor: () => Promise<Partial<{ [key in number]: ClusterModel[] }>> },
-'core': { getClusters: () => Promise<ClusterModel[]>, 
+const ARGS_MAP = { 'core':'{"writeSettings":["setting"],"getUsers":[],"createCluster":["options"],"openMsaLogin":[],"searchPackages":["provider","query"],"killProcess":["pid"],"getGameVersions":[],"open":["input"],"getWorlds":["id"],"launchCluster":["id","uuid"],"removeUser":["uuid"],"isClusterRunning":["cluster_id"],"getPackage":["provider","slug"],"getDefaultUser":["fallback"],"getRunningProcessesByClusterId":["cluster_id"],"getClusterById":["id"],"getMultiplePackages":["provider","slugs"],"readSettings":[],"fetchMinecraftProfile":["uuid"],"getLoadersForVersion":["mc_version"],"setDefaultUser":["uuid"],"getUsersFromAuthor":["provider","author"],"getScreenshots":["id"],"getLogByName":["id","name"],"updateClusterById":["id","request"],"getGlobalProfile":[],"getUser":["uuid"],"updateClusterProfile":["name","profile"],"getPackageBody":["provider","body"],"getPackageVersions":["provider","slug","mc_version","loader","offset","limit"],"removeCluster":["id"],"downloadPackage":["provider","package_id","version_id","cluster_id","skip_compatibility"],"getProfileOrDefault":["name"],"getLogs":["id"],"getClusters":[],"getRunningProcesses":[]}', 'oneclient':'{"openDevTools":[],"getClustersGroupedByMajor":[]}', 'folders':'{"openCluster":["folder_name"],"fromCluster":["folder_name"]}', 'events':'{"ingress":["event"],"message":["event"],"process":["event"]}' }
+export type Router = { 'core': { getClusters: () => Promise<ClusterModel[]>, 
 getClusterById: (id: number) => Promise<ClusterModel | null>, 
 removeCluster: (id: number) => Promise<null>, 
 createCluster: (options: CreateCluster) => Promise<ClusterModel>, 
@@ -271,11 +269,13 @@ downloadPackage: (provider: Provider, packageId: string, versionId: string, clus
 getUsersFromAuthor: (provider: Provider, author: PackageAuthor) => Promise<ManagedUser[]>, 
 fetchMinecraftProfile: (uuid: string) => Promise<MojangPlayerProfile>, 
 open: (input: string) => Promise<null> },
+'folders': { fromCluster: (folderName: string) => Promise<string>, 
+openCluster: (folderName: string) => Promise<null> },
 'events': { ingress: (event: IngressPayload) => Promise<void>, 
 message: (event: MessagePayload) => Promise<void>, 
 process: (event: ProcessPayload) => Promise<void> },
-'folders': { fromCluster: (folderName: string) => Promise<string>, 
-openCluster: (folderName: string) => Promise<null> } };
+'oneclient': { openDevTools: () => Promise<void>, 
+getClustersGroupedByMajor: () => Promise<Partial<{ [key in number]: ClusterModel[] }>> } };
 
 
 export type { InferCommandOutput }

--- a/apps/oneclient/frontend/src/bindings.gen.ts
+++ b/apps/oneclient/frontend/src/bindings.gen.ts
@@ -169,7 +169,7 @@ export type SettingProfileModel = { name: string; java_id: number | null; res: R
 
 export type Settings = { global_game_settings: SettingProfileModel; allow_parallel_running_clusters: boolean; enable_gamemode: boolean; discord_enabled: boolean; max_concurrent_requests: number; settings_version: number; native_window_frame: boolean }
 
-export type SettingsOsExtra = { enable_gamemode: boolean | null }
+export type SettingsOsExtra = Record<string, never>
 
 export type Sort = "Relevance" | "Downloads" | "Newest" | "Updated"
 
@@ -232,10 +232,9 @@ export type VersionType =
  */
 "old_beta"
 
-const ARGS_MAP = { 'core':'{"getUser":["uuid"],"readSettings":[],"searchPackages":["provider","query"],"writeSettings":["setting"],"createCluster":["options"],"fetchMinecraftProfile":["uuid"],"getLoadersForVersion":["mc_version"],"launchCluster":["id","uuid"],"getGlobalProfile":[],"openMsaLogin":[],"open":["input"],"getPackageVersions":["provider","slug","mc_version","loader","offset","limit"],"isClusterRunning":["cluster_id"],"getGameVersions":[],"getMultiplePackages":["provider","slugs"],"setDefaultUser":["uuid"],"downloadPackage":["provider","package_id","version_id","cluster_id","skip_compatibility"],"getLogs":["id"],"getRunningProcesses":[],"getUsersFromAuthor":["provider","author"],"getClusterById":["id"],"getScreenshots":["id"],"getProfileOrDefault":["name"],"getPackageBody":["provider","body"],"getRunningProcessesByClusterId":["cluster_id"],"updateClusterProfile":["name","profile"],"getPackage":["provider","slug"],"removeUser":["uuid"],"updateClusterById":["id","request"],"getWorlds":["id"],"getLogByName":["id","name"],"killProcess":["pid"],"getClusters":[],"removeCluster":["id"],"getDefaultUser":["fallback"],"getUsers":[]}', 'events':'{"message":["event"],"ingress":["event"],"process":["event"]}', 'folders':'{"fromCluster":["folder_name"],"openCluster":["folder_name"]}', 'oneclient':'{"getClustersGroupedByMajor":[],"openDevTools":[]}' }
-export type Router = { 'events': { ingress: (event: IngressPayload) => Promise<void>, 
-message: (event: MessagePayload) => Promise<void>, 
-process: (event: ProcessPayload) => Promise<void> },
+const ARGS_MAP = { 'core':'{"writeSettings":["setting"],"getUsers":[],"createCluster":["options"],"openMsaLogin":[],"searchPackages":["provider","query"],"killProcess":["pid"],"getGameVersions":[],"open":["input"],"getWorlds":["id"],"launchCluster":["id","uuid"],"removeUser":["uuid"],"isClusterRunning":["cluster_id"],"getPackage":["provider","slug"],"getDefaultUser":["fallback"],"getRunningProcessesByClusterId":["cluster_id"],"getClusterById":["id"],"getMultiplePackages":["provider","slugs"],"readSettings":[],"fetchMinecraftProfile":["uuid"],"getLoadersForVersion":["mc_version"],"setDefaultUser":["uuid"],"getUsersFromAuthor":["provider","author"],"getScreenshots":["id"],"getLogByName":["id","name"],"updateClusterById":["id","request"],"getGlobalProfile":[],"getUser":["uuid"],"updateClusterProfile":["name","profile"],"getPackageBody":["provider","body"],"getPackageVersions":["provider","slug","mc_version","loader","offset","limit"],"removeCluster":["id"],"downloadPackage":["provider","package_id","version_id","cluster_id","skip_compatibility"],"getProfileOrDefault":["name"],"getLogs":["id"],"getClusters":[],"getRunningProcesses":[]}', 'events':'{"ingress":["event"],"message":["event"],"process":["event"]}', 'folders':'{"openCluster":["folder_name"],"fromCluster":["folder_name"]}', 'oneclient':'{"openDevTools":[],"getClustersGroupedByMajor":[]}' }
+export type Router = { 'oneclient': { openDevTools: () => Promise<void>, 
+getClustersGroupedByMajor: () => Promise<Partial<{ [key in number]: ClusterModel[] }>> },
 'core': { getClusters: () => Promise<ClusterModel[]>, 
 getClusterById: (id: number) => Promise<ClusterModel | null>, 
 removeCluster: (id: number) => Promise<null>, 
@@ -272,8 +271,9 @@ downloadPackage: (provider: Provider, packageId: string, versionId: string, clus
 getUsersFromAuthor: (provider: Provider, author: PackageAuthor) => Promise<ManagedUser[]>, 
 fetchMinecraftProfile: (uuid: string) => Promise<MojangPlayerProfile>, 
 open: (input: string) => Promise<null> },
-'oneclient': { openDevTools: () => Promise<void>, 
-getClustersGroupedByMajor: () => Promise<Partial<{ [key in number]: ClusterModel[] }>> },
+'events': { ingress: (event: IngressPayload) => Promise<void>, 
+message: (event: MessagePayload) => Promise<void>, 
+process: (event: ProcessPayload) => Promise<void> },
 'folders': { fromCluster: (folderName: string) => Promise<string>, 
 openCluster: (folderName: string) => Promise<null> } };
 

--- a/apps/oneclient/frontend/src/bindings.gen.ts
+++ b/apps/oneclient/frontend/src/bindings.gen.ts
@@ -232,8 +232,10 @@ export type VersionType =
  */
 "old_beta"
 
-const ARGS_MAP = { 'core':'{"writeSettings":["setting"],"getUsers":[],"createCluster":["options"],"openMsaLogin":[],"searchPackages":["provider","query"],"killProcess":["pid"],"getGameVersions":[],"open":["input"],"getWorlds":["id"],"launchCluster":["id","uuid"],"removeUser":["uuid"],"isClusterRunning":["cluster_id"],"getPackage":["provider","slug"],"getDefaultUser":["fallback"],"getRunningProcessesByClusterId":["cluster_id"],"getClusterById":["id"],"getMultiplePackages":["provider","slugs"],"readSettings":[],"fetchMinecraftProfile":["uuid"],"getLoadersForVersion":["mc_version"],"setDefaultUser":["uuid"],"getUsersFromAuthor":["provider","author"],"getScreenshots":["id"],"getLogByName":["id","name"],"updateClusterById":["id","request"],"getGlobalProfile":[],"getUser":["uuid"],"updateClusterProfile":["name","profile"],"getPackageBody":["provider","body"],"getPackageVersions":["provider","slug","mc_version","loader","offset","limit"],"removeCluster":["id"],"downloadPackage":["provider","package_id","version_id","cluster_id","skip_compatibility"],"getProfileOrDefault":["name"],"getLogs":["id"],"getClusters":[],"getRunningProcesses":[]}', 'oneclient':'{"openDevTools":[],"getClustersGroupedByMajor":[]}', 'folders':'{"openCluster":["folder_name"],"fromCluster":["folder_name"]}', 'events':'{"ingress":["event"],"message":["event"],"process":["event"]}' }
-export type Router = { 'core': { getClusters: () => Promise<ClusterModel[]>, 
+const ARGS_MAP = { 'core':'{"writeSettings":["setting"],"getUsers":[],"createCluster":["options"],"openMsaLogin":[],"searchPackages":["provider","query"],"killProcess":["pid"],"getGameVersions":[],"open":["input"],"getWorlds":["id"],"launchCluster":["id","uuid"],"removeUser":["uuid"],"isClusterRunning":["cluster_id"],"getPackage":["provider","slug"],"getDefaultUser":["fallback"],"getRunningProcessesByClusterId":["cluster_id"],"getClusterById":["id"],"getMultiplePackages":["provider","slugs"],"readSettings":[],"fetchMinecraftProfile":["uuid"],"getLoadersForVersion":["mc_version"],"setDefaultUser":["uuid"],"getUsersFromAuthor":["provider","author"],"getScreenshots":["id"],"getLogByName":["id","name"],"updateClusterById":["id","request"],"getGlobalProfile":[],"getUser":["uuid"],"updateClusterProfile":["name","profile"],"getPackageBody":["provider","body"],"getPackageVersions":["provider","slug","mc_version","loader","offset","limit"],"removeCluster":["id"],"downloadPackage":["provider","package_id","version_id","cluster_id","skip_compatibility"],"getProfileOrDefault":["name"],"getLogs":["id"],"getClusters":[],"getRunningProcesses":[]}', 'folders':'{"openCluster":["folder_name"],"fromCluster":["folder_name"]}', 'events':'{"ingress":["event"],"message":["event"],"process":["event"]}', 'oneclient':'{"openDevTools":[],"getClustersGroupedByMajor":[]}' }
+export type Router = { 'oneclient': { openDevTools: () => Promise<void>, 
+getClustersGroupedByMajor: () => Promise<Partial<{ [key in number]: ClusterModel[] }>> },
+'core': { getClusters: () => Promise<ClusterModel[]>, 
 getClusterById: (id: number) => Promise<ClusterModel | null>, 
 removeCluster: (id: number) => Promise<null>, 
 createCluster: (options: CreateCluster) => Promise<ClusterModel>, 
@@ -273,9 +275,7 @@ open: (input: string) => Promise<null> },
 openCluster: (folderName: string) => Promise<null> },
 'events': { ingress: (event: IngressPayload) => Promise<void>, 
 message: (event: MessagePayload) => Promise<void>, 
-process: (event: ProcessPayload) => Promise<void> },
-'oneclient': { openDevTools: () => Promise<void>, 
-getClustersGroupedByMajor: () => Promise<Partial<{ [key in number]: ClusterModel[] }>> } };
+process: (event: ProcessPayload) => Promise<void> } };
 
 
 export type { InferCommandOutput }

--- a/apps/oneclient/frontend/src/routes/app/accounts.tsx
+++ b/apps/oneclient/frontend/src/routes/app/accounts.tsx
@@ -40,7 +40,7 @@ function HeaderLarge() {
 		<div className="flex flex-row justify-between items-end gap-16">
 			<div className="flex-1 flex flex-col">
 				<h1 className="text-3xl font-semibold">Accounts</h1>
-				<p className="text-md font-medium text-fg-secondary">Something something in corporate style fashion about picking your preferred gamemodes and versions and optionally loader so that oneclient can pick something for them</p>
+				<p className="text-md font-medium text-fg-secondary">Login to your Minecraft account here.</p>
 			</div>
 
 			<AddAccountButton size="large" />

--- a/apps/oneclient/frontend/src/routes/app/clusters.tsx
+++ b/apps/oneclient/frontend/src/routes/app/clusters.tsx
@@ -221,7 +221,7 @@ function HeaderLarge() {
 		<div className="flex flex-row justify-between items-end gap-8">
 			<div className="flex flex-col">
 				<h1 className="text-3xl font-semibold">Clusters</h1>
-				<p className="text-md font-medium text-fg-secondary">Something something in corporate style fashion about picking your preferred gamemodes and versions and optionally loader so that oneclient can pick something for them</p>
+				<p className="text-md font-medium text-fg-secondary">Pick what you play and we'll do the rest.</p>
 			</div>
 		</div>
 	);

--- a/apps/oneclient/frontend/src/routes/app/index.tsx
+++ b/apps/oneclient/frontend/src/routes/app/index.tsx
@@ -129,13 +129,15 @@ function RecentsCard({
 
 	return (
 		<Card className={twMerge(active && 'outline-2 outline-brand')} onPress={onPress}>
-			<div className="flex w-full h-full justify-start items-end px-6 py-3 hover:brightness-80">
+			<div className="flex w-full h-full justify-start items-end px-6 py-3 hover:brightness-75 transition-all duration-200">
 				<GameBackground className="absolute -z-10 left-0 top-0 w-full h-full scale-110" name={versionInfo.backgroundName} />
 
 				<div
 					className="absolute top-0 left-0 -z-10 w-full h-full"
 					style={{
 						background: 'linear-gradient(180deg, rgba(25, 25, 25, 0.00) 24.52%, rgba(17, 17, 21, 0.75) 65%)',
+						backdropFilter: 'blur(3px)',
+						WebkitBackdropFilter: 'blur(3px)',
 					}}
 				>
 				</div>
@@ -160,7 +162,7 @@ function Card({
 	return (
 		<AriaButton
 			className={twMerge(
-				'relative overflow-hidden flex-1 rounded-xl outline outline-component-border',
+				'relative overflow-hidden flex-1 rounded-xl outline outline-component-border transition-all duration-300',
 				blur
 					? 'bg-white/5 hover:bg-white/15 active:bg-white/20'
 					: 'hover:bg-ghost-overlay-hover active:bg-ghost-overlay-pressed',

--- a/apps/oneclient/frontend/src/routes/app/index.tsx
+++ b/apps/oneclient/frontend/src/routes/app/index.tsx
@@ -129,20 +129,22 @@ function RecentsCard({
 
 	return (
 		<Card className={twMerge(active && 'outline-2 outline-brand')} onPress={onPress}>
-			<div className="flex w-full h-full justify-start items-end px-6 py-3 hover:brightness-75 transition-all duration-200">
-				<GameBackground className="absolute -z-10 left-0 top-0 w-full h-full scale-110" name={versionInfo.backgroundName} />
+			<div className="relative flex w-full h-full justify-start items-end px-6 py-3">
+				<div className="absolute inset-0 hover:brightness-75 transition-all duration-200">
+					<GameBackground className="absolute -z-10 left-0 top-0 w-full h-full scale-110 pointer-events-none" name={versionInfo.backgroundName} />
 
-				<div
-					className="absolute top-0 left-0 -z-10 w-full h-full"
-					style={{
-						background: 'linear-gradient(180deg, rgba(25, 25, 25, 0.00) 24.52%, rgba(17, 17, 21, 0.75) 65%)',
-						backdropFilter: 'blur(3px)',
-						WebkitBackdropFilter: 'blur(3px)',
-					}}
-				>
+					<div
+						className="absolute top-0 left-0 -z-10 w-full h-full pointer-events-none"
+						style={{
+							background:
+						'linear-gradient(180deg, rgba(25, 25, 25, 0.00) 24.52%, rgba(17, 17, 21, 0.75) 65%)',
+							backdropFilter: 'blur(3px)',
+							WebkitBackdropFilter: 'blur(3px)',
+						}}
+					/>
 				</div>
 
-				<h4 className="text-2xl font-semibold">{version} {prettifyLoader(loader)}</h4>
+				<h4 className="text-2xl font-semibold relative z-10"> {version} {prettifyLoader(loader)} </h4>
 			</div>
 		</Card>
 	);

--- a/apps/oneclient/frontend/src/routes/onboarding/preferences/mods.tsx
+++ b/apps/oneclient/frontend/src/routes/onboarding/preferences/mods.tsx
@@ -13,8 +13,7 @@ function RouteComponent() {
 			<div className="max-w-6xl mx-auto">
 				<h1 className="text-4xl font-semibold mb-2">Choose Mods</h1>
 				<p className="text-slate-400 text-lg mb-2">
-					Something something in corporate style fashion about picking your preferred gamemodes and versions and
-					optionally loader so that oneclient can pick something for them
+					Add mods to your game and experience something new.
 				</p>
 
 				<div className="relative">

--- a/apps/oneclient/frontend/src/routes/onboarding/preferences/versions.tsx
+++ b/apps/oneclient/frontend/src/routes/onboarding/preferences/versions.tsx
@@ -29,8 +29,7 @@ function RouteComponent() {
 			<div className="max-w-6xl mx-auto">
 				<h1 className="text-4xl font-semibold mb-2">Starting Versions</h1>
 				<p className="text-slate-400 text-lg mb-2">
-					Something something in corporate style fashion about picking your preferred gamemodes and versions and
-					optionally loader so that oneclient can pick something for them
+					Pick your preferred version to get going.
 				</p>
 
 				<div className="bg-page-elevated h-full p-4 rounded-xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
## Description

Simply adds some animations to the hovered state with the recent cards on the menu

## How to test

<!-- Provide steps to test this PR -->
Just boot up OneClient and hover over the Recent Cards

## Other notes

Will update this PR as needed when adding other animations, unless it gets accepted
Half related: [#1 in my repo](https://github.com/hablethedev/PF-OneLauncher/issues/1), am working on a fix currently. If I get it fixed will put in this PR probably
This is also my first proper PR like...ever so uhm yeah
