### PR TITLE
fix: oneclient onboarding not forcing an account

### DIFF
--- a/apps/oneclient/frontend/src/bindings.gen.ts
+++ b/apps/oneclient/frontend/src/bindings.gen.ts
@@ -106,7 +106,13 @@ export type ModpackFormat = "CurseForge" | "MrPack" | "PolyMrPack"
 
 export type ModpackManifest = { name: string; version: string; loader: GameLoader; loader_version: string; mc_version: string; files: ModpackFile[] }
 
+export type MojangCape = { id: string; state: string; url: string; alias: string }
+
+export type MojangFullPlayerProfile = { uuid: string; username: string; skins: MojangSkin[]; capes: MojangCape[] }
+
 export type MojangPlayerProfile = { uuid: string; username: string; is_slim: boolean; skin_url: string | null; cape_url: string | null }
+
+export type MojangSkin = { id: string; state: string; url: string; variant: SkinVariant }
 
 export type PackageAuthor = { Team: { team_id: string; org_id: string | null } } | { Users: ManagedUser[] }
 
@@ -181,7 +187,9 @@ export type SettingProfileModel = { name: string; java_id: number | null; res: R
 
 export type Settings = { global_game_settings: SettingProfileModel; allow_parallel_running_clusters: boolean; enable_gamemode: boolean; discord_enabled: boolean; max_concurrent_requests: number; settings_version: number; native_window_frame: boolean }
 
-export type SettingsOsExtra = { enable_gamemode: boolean | null }
+export type SettingsOsExtra = Record<string, never>
+
+export type SkinVariant = "classic" | "slim"
 
 export type Sort = "Relevance" | "Downloads" | "Newest" | "Updated"
 
@@ -244,16 +252,8 @@ export type VersionType =
  */
 "old_beta"
 
-const ARGS_MAP = { 'oneclient':'{"getBundlesFor":["cluster_id"],"openDevTools":[],"getClustersGroupedByMajor":[]}', 'events':'{"ingress":["event"],"message":["event"],"process":["event"]}', 'core':'{"openMsaLogin":[],"getRunningProcesses":[],"launchCluster":["id","uuid"],"getWorlds":["id"],"getPackageVersions":["provider","slug","mc_version","loader","offset","limit"],"searchPackages":["provider","query"],"getPackage":["provider","slug"],"downloadPackage":["provider","package_id","version_id","cluster_id","skip_compatibility"],"getLoadersForVersion":["mc_version"],"removeCluster":["id"],"getUser":["uuid"],"setDefaultUser":["uuid"],"getUsersFromAuthor":["provider","author"],"getMultiplePackages":["provider","slugs"],"getLogs":["id"],"getProfileOrDefault":["name"],"fetchMinecraftProfile":["uuid"],"updateClusterProfile":["name","profile"],"getUsers":[],"killProcess":["pid"],"createCluster":["options"],"removeUser":["uuid"],"getLogByName":["id","name"],"getGlobalProfile":[],"getGameVersions":[],"getClusterById":["id"],"getScreenshots":["id"],"writeSettings":["setting"],"getClusters":[],"installModpack":["modpack","cluster_id"],"getDefaultUser":["fallback"],"open":["input"],"getRunningProcessesByClusterId":["cluster_id"],"isClusterRunning":["cluster_id"],"updateClusterById":["id","request"],"readSettings":[],"getPackageBody":["provider","body"]}', 'folders':'{"fromCluster":["folder_name"],"openCluster":["folder_name"]}' }
-export type Router = { 'events': { ingress: (event: IngressPayload) => Promise<void>, 
-message: (event: MessagePayload) => Promise<void>, 
-process: (event: ProcessPayload) => Promise<void> },
-'folders': { fromCluster: (folderName: string) => Promise<string>, 
-openCluster: (folderName: string) => Promise<null> },
-'oneclient': { openDevTools: () => Promise<void>, 
-getClustersGroupedByMajor: () => Promise<Partial<{ [key in number]: ClusterModel[] }>>, 
-getBundlesFor: (clusterId: number) => Promise<ModpackArchive[]> },
-'core': { getClusters: () => Promise<ClusterModel[]>, 
+const ARGS_MAP = { 'folders':'{"fromCluster":["folder_name"],"openCluster":["folder_name"]}', 'oneclient':'{"openDevTools":[],"getClustersGroupedByMajor":[],"getBundlesFor":["cluster_id"]}', 'core':'{"getClusters":[],"getMultiplePackages":["provider","slugs"],"getProfileOrDefault":["name"],"getRunningProcessesByClusterId":["cluster_id"],"removeCluster":["id"],"writeSettings":["setting"],"getPackage":["provider","slug"],"fetchLoggedInProfile":["access_token"],"getLogByName":["id","name"],"searchPackages":["provider","query"],"getWorlds":["id"],"isClusterRunning":["cluster_id"],"launchCluster":["id","uuid"],"updateClusterProfile":["name","profile"],"getScreenshots":["id"],"fetchMinecraftProfile":["uuid"],"getUsersFromAuthor":["provider","author"],"downloadPackage":["provider","package_id","version_id","cluster_id","skip_compatibility"],"getGameVersions":[],"uploadSkinBytes":["access_token","skin_data","image_format","skin_variant"],"killProcess":["pid"],"openMsaLogin":[],"open":["input"],"getClusterById":["id"],"getGlobalProfile":[],"removeUser":["uuid"],"getRunningProcesses":[],"getDefaultUser":["fallback"],"readSettings":[],"getUsers":[],"getPackageVersions":["provider","slug","mc_version","loader","offset","limit"],"changeSkin":["access_token","skin_url","skin_variant"],"getLoadersForVersion":["mc_version"],"setDefaultUser":["uuid"],"getUser":["uuid"],"getPackageBody":["provider","body"],"getLogs":["id"],"installModpack":["modpack","cluster_id"],"createCluster":["options"],"updateClusterById":["id","request"]}', 'events':'{"ingress":["event"],"process":["event"],"message":["event"]}' }
+export type Router = { 'core': { getClusters: () => Promise<ClusterModel[]>, 
 getClusterById: (id: number) => Promise<ClusterModel | null>, 
 removeCluster: (id: number) => Promise<null>, 
 createCluster: (options: CreateCluster) => Promise<ClusterModel>, 
@@ -289,7 +289,18 @@ downloadPackage: (provider: Provider, packageId: string, versionId: string, clus
 getUsersFromAuthor: (provider: Provider, author: PackageAuthor) => Promise<ManagedUser[]>, 
 installModpack: (modpack: ModpackArchive, clusterId: number) => Promise<null>, 
 fetchMinecraftProfile: (uuid: string) => Promise<MojangPlayerProfile>, 
-open: (input: string) => Promise<null> } };
+fetchLoggedInProfile: (accessToken: string) => Promise<MojangFullPlayerProfile>, 
+uploadSkinBytes: (accessToken: string, skinData: number[], imageFormat: string, skinVariant: SkinVariant) => Promise<MojangSkin>, 
+changeSkin: (accessToken: string, skinUrl: string, skinVariant: SkinVariant) => Promise<MojangSkin>, 
+open: (input: string) => Promise<null> },
+'oneclient': { openDevTools: () => Promise<void>, 
+getClustersGroupedByMajor: () => Promise<Partial<{ [key in number]: ClusterModel[] }>>, 
+getBundlesFor: (clusterId: number) => Promise<ModpackArchive[]> },
+'events': { ingress: (event: IngressPayload) => Promise<void>, 
+message: (event: MessagePayload) => Promise<void>, 
+process: (event: ProcessPayload) => Promise<void> },
+'folders': { fromCluster: (folderName: string) => Promise<string>, 
+openCluster: (folderName: string) => Promise<null> } };
 
 
 export type { InferCommandOutput }

--- a/apps/oneclient/frontend/src/bindings.gen.ts
+++ b/apps/oneclient/frontend/src/bindings.gen.ts
@@ -252,8 +252,11 @@ export type VersionType =
  */
 "old_beta"
 
-const ARGS_MAP = { 'folders':'{"fromCluster":["folder_name"],"openCluster":["folder_name"]}', 'oneclient':'{"openDevTools":[],"getClustersGroupedByMajor":[],"getBundlesFor":["cluster_id"]}', 'core':'{"getClusters":[],"getMultiplePackages":["provider","slugs"],"getProfileOrDefault":["name"],"getRunningProcessesByClusterId":["cluster_id"],"removeCluster":["id"],"writeSettings":["setting"],"getPackage":["provider","slug"],"fetchLoggedInProfile":["access_token"],"getLogByName":["id","name"],"searchPackages":["provider","query"],"getWorlds":["id"],"isClusterRunning":["cluster_id"],"launchCluster":["id","uuid"],"updateClusterProfile":["name","profile"],"getScreenshots":["id"],"fetchMinecraftProfile":["uuid"],"getUsersFromAuthor":["provider","author"],"downloadPackage":["provider","package_id","version_id","cluster_id","skip_compatibility"],"getGameVersions":[],"uploadSkinBytes":["access_token","skin_data","image_format","skin_variant"],"killProcess":["pid"],"openMsaLogin":[],"open":["input"],"getClusterById":["id"],"getGlobalProfile":[],"removeUser":["uuid"],"getRunningProcesses":[],"getDefaultUser":["fallback"],"readSettings":[],"getUsers":[],"getPackageVersions":["provider","slug","mc_version","loader","offset","limit"],"changeSkin":["access_token","skin_url","skin_variant"],"getLoadersForVersion":["mc_version"],"setDefaultUser":["uuid"],"getUser":["uuid"],"getPackageBody":["provider","body"],"getLogs":["id"],"installModpack":["modpack","cluster_id"],"createCluster":["options"],"updateClusterById":["id","request"]}', 'events':'{"ingress":["event"],"process":["event"],"message":["event"]}' }
-export type Router = { 'core': { getClusters: () => Promise<ClusterModel[]>, 
+const ARGS_MAP = { 'events':'{"ingress":["event"],"process":["event"],"message":["event"]}', 'folders':'{"fromCluster":["folder_name"],"openCluster":["folder_name"]}', 'core':'{"getClusters":[],"getMultiplePackages":["provider","slugs"],"getProfileOrDefault":["name"],"getRunningProcessesByClusterId":["cluster_id"],"removeCluster":["id"],"writeSettings":["setting"],"getPackage":["provider","slug"],"fetchLoggedInProfile":["access_token"],"getLogByName":["id","name"],"searchPackages":["provider","query"],"getWorlds":["id"],"isClusterRunning":["cluster_id"],"launchCluster":["id","uuid"],"updateClusterProfile":["name","profile"],"getScreenshots":["id"],"fetchMinecraftProfile":["uuid"],"getUsersFromAuthor":["provider","author"],"downloadPackage":["provider","package_id","version_id","cluster_id","skip_compatibility"],"getGameVersions":[],"uploadSkinBytes":["access_token","skin_data","image_format","skin_variant"],"killProcess":["pid"],"openMsaLogin":[],"open":["input"],"getClusterById":["id"],"getGlobalProfile":[],"removeUser":["uuid"],"getRunningProcesses":[],"getDefaultUser":["fallback"],"readSettings":[],"getUsers":[],"getPackageVersions":["provider","slug","mc_version","loader","offset","limit"],"changeSkin":["access_token","skin_url","skin_variant"],"getLoadersForVersion":["mc_version"],"setDefaultUser":["uuid"],"getUser":["uuid"],"getPackageBody":["provider","body"],"getLogs":["id"],"installModpack":["modpack","cluster_id"],"createCluster":["options"],"updateClusterById":["id","request"]}', 'oneclient':'{"openDevTools":[],"getClustersGroupedByMajor":[],"getBundlesFor":["cluster_id"]}' }
+export type Router = { 'oneclient': { openDevTools: () => Promise<void>, 
+getClustersGroupedByMajor: () => Promise<Partial<{ [key in number]: ClusterModel[] }>>, 
+getBundlesFor: (clusterId: number) => Promise<ModpackArchive[]> },
+'core': { getClusters: () => Promise<ClusterModel[]>, 
 getClusterById: (id: number) => Promise<ClusterModel | null>, 
 removeCluster: (id: number) => Promise<null>, 
 createCluster: (options: CreateCluster) => Promise<ClusterModel>, 
@@ -293,14 +296,11 @@ fetchLoggedInProfile: (accessToken: string) => Promise<MojangFullPlayerProfile>,
 uploadSkinBytes: (accessToken: string, skinData: number[], imageFormat: string, skinVariant: SkinVariant) => Promise<MojangSkin>, 
 changeSkin: (accessToken: string, skinUrl: string, skinVariant: SkinVariant) => Promise<MojangSkin>, 
 open: (input: string) => Promise<null> },
-'oneclient': { openDevTools: () => Promise<void>, 
-getClustersGroupedByMajor: () => Promise<Partial<{ [key in number]: ClusterModel[] }>>, 
-getBundlesFor: (clusterId: number) => Promise<ModpackArchive[]> },
+'folders': { fromCluster: (folderName: string) => Promise<string>, 
+openCluster: (folderName: string) => Promise<null> },
 'events': { ingress: (event: IngressPayload) => Promise<void>, 
 message: (event: MessagePayload) => Promise<void>, 
-process: (event: ProcessPayload) => Promise<void> },
-'folders': { fromCluster: (folderName: string) => Promise<string>, 
-openCluster: (folderName: string) => Promise<null> } };
+process: (event: ProcessPayload) => Promise<void> } };
 
 
 export type { InferCommandOutput }

--- a/apps/oneclient/frontend/src/routes/onboarding/account.tsx
+++ b/apps/oneclient/frontend/src/routes/onboarding/account.tsx
@@ -65,9 +65,11 @@ function RouteComponent() {
 	};
 
 	return (
-		<div className="flex flex-col h-full px-12 gap-8">
-			<h1 className="text-4xl font-semibold mb-2">Account</h1>
-			<p className="text-slate-400 text-lg mb-2">Before you continue, we require you to own a copy of Minecraft: Java Edition.</p>
+		<div className="flex flex-col h-full px-12 gap-4">
+			<div>
+				<h1 className="text-4xl font-semibold mb-2">Account</h1>
+				<p className="text-slate-400 text-lg mb-2">Before you continue, we require you to own a copy of Minecraft: Java Edition.</p>
+			</div>
 			{currentAccount ?
 				<>
 					<AccountPreview profile={currentAccount} />
@@ -92,6 +94,6 @@ function RouteComponent() {
 						)}
 				</>
 			}
-		</div >
+		</div>
 	);
 }

--- a/apps/oneclient/frontend/src/routes/onboarding/account.tsx
+++ b/apps/oneclient/frontend/src/routes/onboarding/account.tsx
@@ -2,7 +2,7 @@ import type { MinecraftCredentials } from '@/bindings.gen';
 import { AccountAvatar, SkinViewer } from '@/components';
 import { usePlayerProfile } from '@/hooks/usePlayerProfile';
 import { bindings } from '@/main';
-import { useCommandMut } from '@onelauncher/common';
+import { useCommandMut, useCommandSuspense } from '@onelauncher/common';
 import { Button } from '@onelauncher/common/components';
 import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
@@ -49,15 +49,11 @@ function AccountPreview({
 	);
 }
 
-// TODO: Block the next button until the user logs in (beg lynith to do it coz I spent 20 minutes on it)
 function RouteComponent() {
 	const queryClient = useQueryClient();
-
+	const { data: currentAccount } = useCommandSuspense(['getDefaultUser'], () => bindings.core.getDefaultUser(true));
 	const { data: profile, isPending, mutate: login } = useCommandMut(bindings.core.openMsaLogin, {
 		onSuccess() {
-			queryClient.invalidateQueries({
-				queryKey: ['getUsers'],
-			});
 			queryClient.invalidateQueries({
 				queryKey: ['getDefaultUser'],
 			});
@@ -72,22 +68,30 @@ function RouteComponent() {
 		<div className="flex flex-col h-full px-12 gap-8">
 			<h1 className="text-4xl font-semibold mb-2">Account</h1>
 			<p className="text-slate-400 text-lg mb-2">Before you continue, we require you to own a copy of Minecraft: Java Edition.</p>
-			{profile
-				? (
-					<>
-						<AccountPreview profile={profile} />
-					</>
-				)
-				: (
-					<Button
-						color="primary"
-						isPending={isPending}
-						onClick={onClick}
-						size="large"
-					>
-						Add Account
-					</Button>
-				)}
+			{currentAccount ?
+				<>
+					<AccountPreview profile={currentAccount} />
+				</>
+				:
+				<>
+					{profile
+						? (
+							<>
+								<AccountPreview profile={profile} />
+							</>
+						)
+						: (
+							<Button
+								color="primary"
+								isPending={isPending}
+								onClick={onClick}
+								size="large"
+							>
+								Add Account
+							</Button>
+						)}
+				</>
+			}
 		</div >
 	);
 }

--- a/apps/oneclient/frontend/src/routes/onboarding/route.tsx
+++ b/apps/oneclient/frontend/src/routes/onboarding/route.tsx
@@ -4,7 +4,9 @@ import LauncherLogo from '@/assets/logos/oneclient.svg?react';
 import { LoaderSuspense, NavbarButton } from '@/components';
 import { GameBackground } from '@/components/GameBackground';
 import { Stepper } from '@/components/Stepper';
+import { bindings } from '@/main';
 import useAppShellStore from '@/stores/appShellStore';
+import { useCommandSuspense } from '@onelauncher/common';
 import { Button } from '@onelauncher/common/components';
 import { createFileRoute, Link, Outlet } from '@tanstack/react-router';
 import { Window } from '@tauri-apps/api/window';
@@ -175,21 +177,23 @@ function BackgroundGradient() {
 }
 
 export function OnboardingNavigation() {
-	const { isFirstStep, isLastStep, previousPath, nextPath } = Route.useLoaderData();
+	const { isFirstStep, isLastStep, previousPath, nextPath, currentStepIndex } = Route.useLoaderData();
+	const { data: currentAccount } = useCommandSuspense(['getDefaultUser'], () => bindings.core.getDefaultUser(true));
+	const disabled = currentStepIndex === 2 && currentAccount === null;
 
 	return (
 		<div className="absolute bottom-2 right-2 flex flex-row gap-2">
 			<div>
 				{!isFirstStep && previousPath && (
 					<Link to={previousPath}>
-						<Button className="w-32" color="ghost">Back</Button>
+						<Button className="w-32" color="secondary">Back</Button>
 					</Link>
 				)}
 			</div>
 			<div>
 				{nextPath && (
-					<Link to={nextPath}>
-						<Button className="w-32">{isLastStep ? 'Finish' : 'Next'}</Button>
+					<Link disabled={disabled} to={nextPath}>
+						<Button className={`w-32 ${disabled ? "line-through" : ""}`} color={disabled ? 'ghost' : 'primary'}>{isLastStep ? 'Finish' : 'Next'}</Button>
 					</Link>
 				)}
 			</div>


### PR DESCRIPTION
## Description
Next button gets disabled and now has a strike through it. Could also just remove the button but I feel this looks better

Blocking next button
<img width="1280" height="802" alt="61w9kbbi" src="https://github.com/user-attachments/assets/84cfa6e7-dd6a-4525-b4b4-9109138ca215" />

Unblocked next button
<img width="1280" height="802" alt="gvvy56ks" src="https://github.com/user-attachments/assets/1896ef0a-6805-426f-b987-7b6f25172bf9" />


<!-- Describe your changes in detail along with its rationale -->

## Related Issue(s)

<!-- List the issue(s) this PR solves, if any -->
Fixes #

## How to test

<!-- Provide steps to test this PR -->

## Documentation

<!--
Does this PR require updates to the documentation at docs.polyfrost.org?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/Nexus/issues/new?assignees=&labels=bug&template=new_feature.yml
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility at https://contributing.polyfrost.org/)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
