### PR TITLE
test

### DIFF
--- a/apps/desktop/src/api/commands/mod.rs
+++ b/apps/desktop/src/api/commands/mod.rs
@@ -89,6 +89,8 @@ macro_rules! collect_commands {
 			get_zulu_packages,
 			install_java_from_package,
 			open_dev_tools,
+			check_java,
+			locate_java,
 		]
 	}};
 }
@@ -116,6 +118,18 @@ pub async fn install_java_from_package(download: onelauncher::java::JavaZuluPack
 #[tauri::command]
 pub async fn get_featured_packages() -> Result<Vec<onelauncher::package::content::FeaturedPackage>, String> {
 	Ok(onelauncher::package::content::get_featured_packages().await?)
+}
+
+#[specta::specta]
+#[tauri::command]
+pub async fn check_java(path: std::path::PathBuf) -> Result<Option<onelauncher::prelude::JavaVersion>, String> {
+	Ok(onelauncher::java::check_java(path).await?)
+}
+
+#[specta::specta]
+#[tauri::command]
+pub async fn locate_java() -> Result<Vec<onelauncher::prelude::JavaVersion>, String> {
+	Ok(onelauncher::utils::java::locate_java().await.map_err(|e| e.to_string())?)
 }
 
 #[specta::specta]

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -6,7 +6,7 @@
 		"withGlobalTauri": true,
 		"macOSPrivateApi": true,
 		"security": {
-			"csp": null,
+			"csp": "img-src 'self' asset: http://asset.localhost",
 			"assetProtocol": {
 				"enable": true,
 				"scope": {

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -6,7 +6,7 @@
 		"withGlobalTauri": true,
 		"macOSPrivateApi": true,
 		"security": {
-			"csp": "img-src 'self' asset: http://asset.localhost",
+			"csp": null,
 			"assetProtocol": {
 				"enable": true,
 				"scope": {

--- a/apps/frontend/src/ui/components/game/ClusterCover.tsx
+++ b/apps/frontend/src/ui/components/game/ClusterCover.tsx
@@ -27,7 +27,7 @@ function ClusterCover(props: ClusterCoverProps) {
 		if (url.startsWith('/'))
 			return convertFileSrc(url);
 
-		return url;
+		return convertFileSrc(url);
 	};
 
 	const Wrapper = (props: ParentProps) => (

--- a/apps/frontend/src/ui/components/game/ClusterCover.tsx
+++ b/apps/frontend/src/ui/components/game/ClusterCover.tsx
@@ -24,9 +24,6 @@ function ClusterCover(props: ClusterCoverProps) {
 		if (url === undefined || url === null)
 			return split.fallback || defaultCover;
 
-		if (url.startsWith('/'))
-			return convertFileSrc(url);
-
 		return convertFileSrc(url);
 	};
 

--- a/apps/frontend/src/ui/pages/cluster/ClusterSettings.tsx
+++ b/apps/frontend/src/ui/pages/cluster/ClusterSettings.tsx
@@ -80,7 +80,6 @@ function PageSettings(cluster: Accessor<Cluster>) {
 			<GameSettings
 				{...{
 					fullscreen,
-					memory,
 					resolution,
 				}}
 			/>
@@ -107,6 +106,7 @@ function PageSettings(cluster: Accessor<Cluster>) {
 					javaVersions,
 					javaArgs,
 					envVars,
+					memory,
 				}}
 			/>
 		</>

--- a/apps/frontend/src/ui/pages/settings/game/SettingsMinecraft.tsx
+++ b/apps/frontend/src/ui/pages/settings/game/SettingsMinecraft.tsx
@@ -478,6 +478,7 @@ function ClusterJavaVersionModal(props: ModalProps & {
 		if (!javaVersion) {
 			const clusterId = props.clusterId;
 			const optimal = await tryResult(() => bridge.commands.getOptimalJavaVersion(clusterId));
+			setPackage(optimal, optimal.version)
 			setSelected(javaVersions().findIndex(([_, meta]) => meta.path === optimal.path));
 		}
 		else {

--- a/apps/frontend/src/ui/pages/settings/game/SettingsMinecraft.tsx
+++ b/apps/frontend/src/ui/pages/settings/game/SettingsMinecraft.tsx
@@ -1,8 +1,7 @@
-import type { JavaVersion, JavaVersions, JavaZuluPackage, Memory, Resolution } from '@onelauncher/client/bindings';
-import { ActivityIcon, CpuChip01Icon, Database01Icon, Download01Icon, EyeIcon, FilePlus02Icon, FileX02Icon, LayoutTopIcon, Maximize01Icon, ParagraphWrapIcon, VariableIcon, XIcon } from '@untitled-theme/icons-solid';
+import type { JavaVersion, JavaVersions, Memory, Resolution } from '@onelauncher/client/bindings';
+import { ActivityIcon, CpuChip01Icon, Database01Icon, EyeIcon, FilePlus02Icon, FileX02Icon, FolderSearchIcon, LayoutTopIcon, ListIcon, Maximize01Icon, ParagraphWrapIcon, VariableIcon, XIcon } from '@untitled-theme/icons-solid';
 import { bridge } from '~imports';
 import Button from '~ui/components/base/Button';
-import Dropdown from '~ui/components/base/Dropdown';
 import TextField from '~ui/components/base/TextField';
 import Toggle from '~ui/components/base/Toggle';
 import Modal, { createModal, type ModalProps } from '~ui/components/overlay/Modal';
@@ -13,6 +12,8 @@ import { tryResult } from '~ui/hooks/useCommand';
 import useSettings from '~ui/hooks/useSettings';
 import { asEnvVariables } from '~utils';
 import { type Accessor, createMemo, createResource, createSignal, For, onMount, type Setter, Show, splitProps, untrack } from 'solid-js';
+import { open } from '@tauri-apps/plugin-dialog';
+import useNotifications from '~ui/hooks/useNotifications';
 
 function SettingsMinecraft() {
 	return (
@@ -106,7 +107,6 @@ function SettingsRow(props: SettingsRowProps & {
 export function GameSettings(props: {
 	fullscreen: CreateSetting<boolean>;
 	resolution: CreateSetting<Resolution>;
-	memory: CreateSetting<Memory>;
 }) {
 	return (
 		<>
@@ -148,45 +148,6 @@ export function GameSettings(props: {
 						}}
 						value={props.resolution.get()[1]}
 					/>
-				</div>
-			</SettingsRow>
-
-			{/* TODO: make this a memory slider */}
-			<SettingsRow
-				description="The amount of memory in megabytes allocated for the game."
-				icon={<Database01Icon />}
-				isGlobal={props.memory.isGlobal}
-				reset={props.memory.resetToFallback}
-				title="Memory"
-			>
-				<div class="flex items-center gap-x-4 flex-justify-center">
-					<div class="flex flex-row items-center gap-x-2">
-						<span>Min:</span>
-						<TextField.Number
-							class="text-center"
-							labelClass="w-[70px]!"
-							max={props.memory.get().maximum}
-							min={1}
-							onValidSubmit={(value) => {
-								props.memory.set({ minimum: Number.parseInt(value), maximum: props.memory.get().maximum });
-							}}
-							value={props.memory.get().minimum}
-						/>
-					</div>
-
-					<div class="flex flex-row items-center gap-x-2">
-						<span>Max:</span>
-						<TextField.Number
-							class="text-center"
-							labelClass="w-[70px]!"
-							max={Number.MAX_SAFE_INTEGER}
-							min={props.memory.get().minimum}
-							onValidSubmit={(value) => {
-								props.memory.set({ minimum: props.memory.get().minimum, maximum: Number.parseInt(value) });
-							}}
-							value={props.memory.get().maximum}
-						/>
-					</div>
 				</div>
 			</SettingsRow>
 		</>
@@ -298,6 +259,7 @@ export function ProcessSettings(props: {
 export function JvmSettings(props: {
 	javaArgs: CreateSetting<string[]>;
 	envVars: CreateSetting<[string, string][]>;
+	memory: CreateSetting<Memory>;
 } & ({
 	clusterId: string;
 	javaVersion: CreateSetting<JavaVersion | null>;
@@ -309,11 +271,14 @@ export function JvmSettings(props: {
 	const modal = createModal((controller) => {
 		if (props.javaVersion)
 			return (
-				<ClusterJavaVersionModal
+				<ClusterJavaSettingsModal
 					{...controller}
 					clusterId={props.clusterId}
 					javaVersion={props.javaVersion}
 					javaVersions={props.javaVersions}
+					envVars={props.envVars}
+					javaArgs={props.javaArgs}
+					memory={props.memory}
 				/>
 			);
 		else return (
@@ -326,53 +291,19 @@ export function JvmSettings(props: {
 
 	return (
 		<>
-			<BaseSettingsRow.Header>Java</BaseSettingsRow.Header>
+			<BaseSettingsRow.Header>Java and Memory</BaseSettingsRow.Header>
 
 			<SettingsRow
-				description="Choose the JRE (Java Runtime Environment) used for the game."
+				description="Configure Java version and memory settings for the game."
 				icon={<CpuChip01Icon />}
 				isGlobal={() => true}
 				reset={() => {}}
-				title="Version"
+				title="Java Version and Memory"
 			>
 				<Button
-					children="Configure"
+					children="Open Settings"
 					iconLeft={<Database01Icon />}
 					onClick={modal.show}
-				/>
-			</SettingsRow>
-
-			<SettingsRow
-				description="Additional arguments passed to the JVM (Java Virtual Machine)."
-				icon={<FilePlus02Icon />}
-				isGlobal={props.javaArgs.isGlobal}
-				reset={props.javaArgs.resetToFallback}
-				title="Arguments"
-			>
-				<TextField
-					labelClass="w-full! min-w-[260px]!"
-					onValidSubmit={(value) => {
-						props.javaArgs.set(value.split(' '));
-					}}
-					placeholder='"-Xmx3G"'
-					value={props.javaArgs.get().join(' ')}
-				/>
-			</SettingsRow>
-
-			<SettingsRow
-				description="Additional environment variables passed to the JVM (Java Virtual Machine)."
-				icon={<VariableIcon />}
-				isGlobal={props.envVars.isGlobal}
-				reset={props.envVars.resetToFallback}
-				title="Environment Variables"
-			>
-				<TextField
-					labelClass="w-full! min-w-[260px]!"
-					onValidSubmit={(value) => {
-						props.envVars.set(asEnvVariables(value));
-					}}
-					placeholder='"JAVA_HOME=/path/to/java"'
-					value={props.envVars.get().join(' ')}
 				/>
 			</SettingsRow>
 		</>
@@ -429,7 +360,6 @@ function PageSettings() {
 			<GameSettings
 				{...{
 					fullscreen,
-					memory,
 					resolution,
 				}}
 			/>
@@ -455,6 +385,7 @@ function PageSettings() {
 					javaVersions,
 					javaArgs,
 					envVars,
+					memory
 				}}
 			/>
 		</>
@@ -463,15 +394,16 @@ function PageSettings() {
 
 export default SettingsMinecraft;
 
-function ClusterJavaVersionModal(props: ModalProps & {
+function ClusterJavaSettingsModal(props: ModalProps & {
 	clusterId: string;
 	javaVersion: CreateSetting<JavaVersion | null>;
 	javaVersions: CreateSetting<JavaVersions>;
+	envVars: CreateSetting<[string, string][]>;
+	javaArgs: CreateSetting<string[]>;
+	memory: CreateSetting<Memory>;
 }) {
 	const [_, modalProps] = splitProps(props, ['javaVersion', 'javaVersions']);
-
-	const javaVersions = createMemo(() => Object.entries(props.javaVersions.get()).sort((a, b) => Number.parseFloat(b[1].version) - Number.parseFloat(a[1].version)));
-	const [selected, setSelected] = createSignal<number>(0);
+	const notifications = useNotifications();
 
 	onMount(async () => {
 		const javaVersion = props.javaVersion.get();
@@ -479,11 +411,10 @@ function ClusterJavaVersionModal(props: ModalProps & {
 			const clusterId = props.clusterId;
 			const optimal = await tryResult(() => bridge.commands.getOptimalJavaVersion(clusterId));
 			setPackage(optimal, optimal.version)
-			setSelected(javaVersions().findIndex(([_, meta]) => meta.path === optimal.path));
 		}
+		// idk but something about this if feels off
 		else {
-			const found = javaVersions().findIndex(([_, meta]) => meta.path === javaVersion.path);
-			setSelected(found);
+			setPackage(javaVersion, javaVersion.version)
 		}
 	});
 
@@ -495,43 +426,126 @@ function ClusterJavaVersionModal(props: ModalProps & {
 		});
 	};
 
-	const onChange = (selected: number) => {
-		const version = javaVersions()[selected]?.[0];
-		if (!version)
-			return;
+	const modal = createModal((controller) => {
+		return (
+			<ListInstalledJavaVersionsModal {...controller} setPackage={setPackage} />
+		)
+	});
 
-		const meta = props.javaVersions.get()[version];
-		if (!meta)
-			return;
+	const searchJava = async () => {
+		const path = await open({
+			multiple: false,
+			directory: true
+		})
 
-		setPackage(meta, version);
-	};
+		const res = await tryResult(() => bridge.commands.checkJava(path as string))
+
+		if (res != null) {
+			setPackage(res, res.version)
+			notifications.create({
+				message: "Java " + res.version + " selected",
+				title: "Success" 
+			})
+		} else {
+			notifications.create({
+				title: "No java found",
+				message: "We really tried but we cant find a java binary"
+			})
+		}
+	}
 
 	return (
 		<BaseJavaVersionModal
 			{...modalProps}
-			setPackage={setPackage}
 		>
-			<h4>Java Path</h4>
-			<div class="flex flex-col items-stretch gap-y-2">
-				<Dropdown onChange={onChange} selected={selected}>
-					<For each={javaVersions()}>
-						{([version]) => {
-							const major = version.toLowerCase().replaceAll('_', ' ').replaceAll('java', '');
+			<SettingsRow
+				description="Path to java executable path"
+				icon={<VariableIcon />}
+				isGlobal={props.javaVersion.isGlobal}
+				reset={props.javaVersion.resetToFallback}
+				title="Java Path"
+			>
+				<Button children="Auto Detect" class='w-full' onClick={modal.show} iconLeft={<ListIcon />} />
+				<Button children="Search" onClick={searchJava} iconRight={<FolderSearchIcon />} />
+				
+				<TextField
+					labelClass="w-full! min-w-[260px]!"
+					placeholder="/path/to/java"
+					value={props.javaVersion.get()?.path}
+				/>
+			</SettingsRow>
 
-							return (
-								<Dropdown.Row>
-									<span class="capitalize">
-										Java
-										{' '}
-										{major}
-									</span>
-								</Dropdown.Row>
-							);
-						}}
-					</For>
-				</Dropdown>
-			</div>
+			<SettingsRow
+				description="Additional arguments passed to the JVM (Java Virtual Machine)."
+				icon={<FilePlus02Icon />}
+				isGlobal={props.javaArgs.isGlobal}
+				reset={props.javaArgs.resetToFallback}
+				title="Arguments"
+			>
+				<TextField
+					labelClass="w-full! min-w-[260px]!"
+					onValidSubmit={(value) => {
+						props.javaArgs.set(value.split(' '));
+					}}
+					placeholder='"-Xmx3G"'
+					value={props.javaArgs.get().join(' ')}
+				/>
+			</SettingsRow>
+
+			<SettingsRow
+				description="Additional environment variables passed to the JVM (Java Virtual Machine)."
+				icon={<VariableIcon />}
+				isGlobal={props.envVars.isGlobal}
+				reset={props.envVars.resetToFallback}
+				title="Environment Variables"
+			>
+				<TextField
+					labelClass="w-full! min-w-[260px]!"
+					onValidSubmit={(value) => {
+						props.envVars.set(asEnvVariables(value));
+					}}
+					placeholder='"JAVA_HOME=/path/to/java"'
+					value={props.envVars.get().join(' ')}
+				/>
+			</SettingsRow>
+
+			<SettingsRow
+				description="The amount of memory in megabytes allocated for the game."
+				icon={<Database01Icon />}
+				isGlobal={props.memory.isGlobal}
+				reset={props.memory.resetToFallback}
+				title="Memory"
+			>
+				<div class="flex items-center gap-x-4 flex-justify-center">
+					<div class="flex flex-row items-center gap-x-2">
+						<span>Min:</span>
+						<TextField.Number
+							class="text-center"
+							labelClass="w-[70px]!"
+							max={props.memory.get().maximum}
+							min={1}
+							onValidSubmit={(value) => {
+								props.memory.set({ minimum: Number.parseInt(value), maximum: props.memory.get().maximum });
+							}}
+							value={props.memory.get().minimum}
+						/>
+					</div>
+
+					<div class="flex flex-row items-center gap-x-2">
+						<span>Max:</span>
+						<TextField.Number
+							class="text-center"
+							labelClass="w-[70px]!"
+							max={Number.MAX_SAFE_INTEGER}
+							min={props.memory.get().minimum}
+							onValidSubmit={(value) => {
+								props.memory.set({ minimum: props.memory.get().minimum, maximum: Number.parseInt(value) });
+							}}
+							value={props.memory.get().maximum}
+						/>
+					</div>
+				</div>
+			</SettingsRow>
 		</BaseJavaVersionModal>
 	);
 }
@@ -551,7 +565,6 @@ function GlobalJavaVersionModal(props: ModalProps & {
 	return (
 		<BaseJavaVersionModal
 			{...modalProps}
-			setPackage={setPackage}
 		>
 			<h4>Default Java Paths</h4>
 			<div class="grid grid-cols-[80px_1fr] items-center gap-y-2">
@@ -581,35 +594,7 @@ function GlobalJavaVersionModal(props: ModalProps & {
 	);
 }
 
-function BaseJavaVersionModal(props: ModalProps & {
-	setPackage: (pkg: JavaVersion, version: string) => void;
-}) {
-	const [selectedPackageIndex, setSelectedPackageIndex] = createSignal<number>(-1);
-
-	const [zuluPackages] = createResource(async () => {
-		try {
-			return await tryResult(bridge.commands.getZuluPackages);
-		}
-		catch (e) {
-			console.error(e);
-			return [];
-		}
-	});
-
-	const foundVersions = createMemo(() => {
-		return zuluPackages()?.map(pkg => pkg.java_version.join('.')) ?? [];
-	});
-
-	const download = async (pkg: JavaZuluPackage) => {
-		const path = await tryResult(() => bridge.commands.installJavaFromPackage(pkg));
-		if (path)
-			props.setPackage({
-				version: pkg.java_version.join('.'),
-				path,
-				arch: '',
-			}, pkg.java_version[0]!.toString());
-	};
-
+function BaseJavaVersionModal(props: ModalProps) {
 	return (
 		<Modal.Simple
 			buttons={[
@@ -619,33 +604,78 @@ function BaseJavaVersionModal(props: ModalProps & {
 					onClick={props.hide}
 				/>,
 			]}
-			title="Java Versions"
+			title="Java Settings"
 			{...props}
 		>
-			<div class="flex flex-col gap-6">
-				<div class="flex flex-col gap-2">
-					{props.children}
-				</div>
-
-				<div class="flex flex-col gap-2">
-					<h4>Download Java</h4>
-					<div class="w-full flex flex-row gap-2">
-						<Dropdown class="w-full" onChange={setSelectedPackageIndex}>
-							<For each={foundVersions()}>
-								{version => (
-									<Dropdown.Row>{version}</Dropdown.Row>
-								)}
-							</For>
-						</Dropdown>
-
-						<Button
-							children="Download"
-							iconLeft={<Download01Icon />}
-							onClick={() => download(zuluPackages()![selectedPackageIndex()]!)}
-						/>
-					</div>
-				</div>
+			<div class="flex flex-col text-start gap-2 w-4xl">
+				{props.children}
 			</div>
 		</Modal.Simple>
 	);
+}
+
+function ListInstalledJavaVersionsModal(props: ModalProps & {
+	setPackage: (pkg: JavaVersion, version: string) => void;
+}) {
+	const [javaInstallations] = createResource(async () => {
+		try {
+			const javaPaths = await tryResult(bridge.commands.locateJava)
+			
+			return javaPaths.filter((data) => !data.path.includes("OneLauncher"))
+		}
+		catch (e) {
+			console.error(e);
+			return [];
+		}
+	});
+
+	function SelectButton({ version }: { version: JavaVersion }) {
+		return (
+			<Button
+				children="Select"
+				onClick={() => {
+					props.setPackage(version, version.version);
+					props.hide();
+				}}
+			/>
+		);
+	}
+	
+	return (
+		<Modal.Simple
+			buttons={[
+				<Button 
+					buttonStyle="secondary"
+					children="Close"
+					onClick={props.hide}
+				/>,
+			]}
+			title="Java Versions"
+			{...props}
+		>
+			<div>
+				<table class="w-full bg-component-bg rounded-lg">
+					<thead>
+						<tr class="text-left">
+							<th class="p-2">Version</th>
+							<th class="p-2">Path</th>
+							<th class="p-2">Architecture</th>
+						</tr>
+					</thead>
+					<tbody>
+						<For each={javaInstallations()}>
+							{(item) => (
+								<tr class="border-t border-white/5">
+									<td class="p-2">{item.version}</td>
+									<td class="p-2">{item.path}</td>
+									<td class="p-2">{item.arch}</td>
+									<td class="p-2"><SelectButton version={item} /></td>
+								</tr>
+							)}
+						</For>
+					</tbody>
+				</table>
+			</div>
+		</Modal.Simple>
+	)
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to new Tauri commands and changed Java selection flow, plus a behavior change that now runs `convertFileSrc` for all cover URLs which could break non-file image sources.
> 
> **Overview**
> Adds two new desktop Tauri commands, `check_java` (validate a selected directory contains a Java binary) and `locate_java` (enumerate installed Javas), exposing them to the frontend.
> 
> Refactors cluster/global settings UI to **merge Java and memory configuration into a single modal**, including auto-detect (list installed Javas) and manual search via directory picker with notifications; memory inputs are moved out of `GameSettings` into this Java modal.
> 
> Updates `ClusterCover` to always call `convertFileSrc` for the chosen icon path/URL, removing the prior conditional handling for non-file URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6792d3e545dce4d9a015ef18325fb89de52c9331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->