### PR TITLE
fix: disable webkit dmabuf renderer on nvidia + wayland

### DIFF
--- a/apps/oneclient/desktop/src/main.rs
+++ b/apps/oneclient/desktop/src/main.rs
@@ -1,7 +1,14 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-#[tokio::main]
-async fn main() {
-	oneclient_gui::run().await;
+fn main() {
+	// Must run before the async runtime spawns any threads and before the
+	// webview initialises (see onelauncher_core::platform).
+	onelauncher_core::platform::apply_startup_workarounds();
+
+	tokio::runtime::Builder::new_multi_thread()
+		.enable_all()
+		.build()
+		.expect("failed to build tokio runtime")
+		.block_on(oneclient_gui::run());
 }

--- a/apps/onelauncher/desktop/src/main.rs
+++ b/apps/onelauncher/desktop/src/main.rs
@@ -1,7 +1,14 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-#[tokio::main]
-async fn main() {
-	onelauncher_gui::run().await;
+fn main() {
+	// Must run before the async runtime spawns any threads and before the
+	// webview initialises (see onelauncher_core::platform).
+	onelauncher_core::platform::apply_startup_workarounds();
+
+	tokio::runtime::Builder::new_multi_thread()
+		.enable_all()
+		.build()
+		.expect("failed to build tokio runtime")
+		.block_on(onelauncher_gui::run());
 }

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -14,6 +14,7 @@ use store::{Core, CoreOptions, Dirs, State};
 pub mod api;
 pub mod constants;
 pub mod error;
+pub mod platform;
 pub mod store;
 pub mod utils;
 

--- a/packages/core/src/platform.rs
+++ b/packages/core/src/platform.rs
@@ -1,0 +1,42 @@
+//! Platform-specific startup workarounds.
+//!
+//! These run before the async runtime is started and before any GUI/webview
+//! initialisation, so they must stay dependency-free and side-effect-light.
+
+/// Apply platform workarounds that must take effect before the webview starts.
+///
+/// On Linux this disables webkit2gtk's DMABUF renderer on Wayland sessions that
+/// use the NVIDIA proprietary driver. There, the DMABUF path hands the
+/// compositor buffers it rejects and GTK aborts with "Error 71 (Protocol
+/// error)" before the window can open, so the app never starts. Disabling the
+/// DMABUF renderer avoids the crash at a small webview-compositing cost, so it
+/// is only applied for the affected configuration and never clobbers a value
+/// the user set themselves.
+///
+/// See <https://github.com/Polyfrost/OneLauncher/issues/496>.
+#[cfg(target_os = "linux")]
+pub fn apply_startup_workarounds() {
+	// Respect an explicit user override either way.
+	if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_some() {
+		return;
+	}
+
+	let wayland = std::env::var_os("WAYLAND_DISPLAY").is_some()
+		|| std::env::var_os("XDG_SESSION_TYPE").is_some_and(|t| t.eq_ignore_ascii_case("wayland"));
+
+	let nvidia = std::path::Path::new("/dev/nvidia0").exists()
+		|| std::path::Path::new("/proc/driver/nvidia/version").exists();
+
+	if wayland && nvidia {
+		// SAFETY: called as the first statement of `main`, before the async
+		// runtime is built and before any other thread is spawned, so nothing
+		// else can be touching the process environment concurrently.
+		unsafe {
+			std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+		}
+	}
+}
+
+/// No-op on non-Linux targets.
+#[cfg(not(target_os = "linux"))]
+pub fn apply_startup_workarounds() {}


### PR DESCRIPTION
## What

NVIDIA + Wayland users can't launch OneClient/OneLauncher: GTK aborts with `Error 71 (Protocol error)` before the window opens. Fixes #496.

## Why

webkit2gtk's DMABUF GL renderer hands the compositor buffers that the NVIDIA driver on Wayland rejects, killing the process during webview init. The workaround confirmed in #496 is `WEBKIT_DISABLE_DMABUF_RENDERER=1` (`__NV_DISABLE_EXPLICIT_SYNC=1` also works).

## How

Adds `onelauncher_core::platform::apply_startup_workarounds()`, called at the very start of each desktop `main()`, before the async runtime spawns any threads and before the webview initialises, so the `set_var` is sound on edition 2024.

It only sets the variable when **all** of:
- the target is Linux,
- the session is Wayland (`WAYLAND_DISPLAY` / `XDG_SESSION_TYPE`),
- an NVIDIA driver is present (`/dev/nvidia0` or `/proc/driver/nvidia/version`),
- and the user hasn't already set `WEBKIT_DISABLE_DMABUF_RENDERER`.

So AMD/Intel and non-Wayland keep the faster DMABUF path, and an explicit user value is always respected. Happy to widen the gate (e.g. all Wayland) if you'd rather.

## Testing

- `cargo check -p onelauncher_core --features tauri` passes on the pinned `nightly-2025-09-12`.
- Verified the detection on Hyprland + NVIDIA proprietary: it sets the variable on that configuration and is a no-op when the conditions don't hold or the user already set it.
- Root cause and the workaround itself are as reported and confirmed in #496.