### PR TITLE
feat(macos): full macOS support - fix java detection, install path, and dyld env

### DIFF
--- a/packages/core/src/api/game/launch.rs
+++ b/packages/core/src/api/game/launch.rs
@@ -199,8 +199,11 @@ pub async fn launch_minecraft(
 		})
 	});
 
+	// On macOS, always remove DYLD_FALLBACK_LIBRARY_PATH which can interfere with
+	// LWJGL native library loading for OpenAL and other native libraries.
+	// This is necessary for both debug (cargo sets it) and release builds.
 	#[cfg(target_os = "macos")]
-	if std::env::var("CARGO").is_ok() {
+	{
 		command.env_remove("DYLD_FALLBACK_LIBRARY_PATH");
 	}
 

--- a/packages/core/src/api/java/mod.rs
+++ b/packages/core/src/api/java/mod.rs
@@ -308,23 +308,55 @@ fn internal_locate_java() -> Vec<PathBuf> {
 fn internal_locate_java() -> Vec<PathBuf> {
 	let mut found = Vec::new();
 
-	// TODO(macos): More paths for Java installations
+	// Standard macOS JDK location: /Library/Java/JavaVirtualMachines/*.jdk/Contents/Home/bin/java
+	if let Ok(entries) = std::fs::read_dir("/Library/Java/JavaVirtualMachines") {
+		for entry in entries.flatten() {
+			let java_bin = entry
+				.path()
+				.join("Contents")
+				.join("Home")
+				.join("bin")
+				.join(JAVA_BIN);
+			if java_bin.exists() {
+				found.push(java_bin);
+			}
+		}
+	}
 
-	let paths = vec![
-		r"/System/Library/Frameworks/JavaVM.framework/Versions/Current/Commands",
-		r"/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/MacOS/itms/java",
-		r"/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home",
-	];
+	// System Java VM framework /usr/bin/java (the Apple-provided stub)
+	let sys_java = PathBuf::from(
+		"/System/Library/Frameworks/JavaVM.framework/Versions/Current/Commands",
+	)
+	.join(JAVA_BIN);
+	if sys_java.exists() {
+		found.push(sys_java);
+	}
 
-	for path in paths {
-		let path = PathBuf::from(path).join(get_java_bin());
-		if path.exists() {
-			found.push(path);
+	// Java Applet Plugin (JRE)
+	let plugin_java = PathBuf::from(
+		"/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home",
+	)
+	.join("bin")
+	.join(JAVA_BIN);
+	if plugin_java.exists() {
+		found.push(plugin_java);
+	}
+
+	// SDKMAN installations
+	if let Ok(home) = std::env::var("HOME") {
+		let sdkman_dir =
+			PathBuf::from(home).join(".sdkman").join("candidates").join("java");
+		if let Ok(entries) = std::fs::read_dir(sdkman_dir) {
+			for entry in entries.flatten() {
+				let java_bin = entry.path().join("bin").join(JAVA_BIN);
+				if java_bin.exists() {
+					found.push(java_bin);
+				}
+			}
 		}
 	}
 
 	found = find_java_in_path(found);
-
 	found
 }
 
@@ -449,12 +481,6 @@ pub async fn install_java_package(package: &JavaPackage) -> LauncherResult<PathB
 			.to_string_lossy()
 			.to_string(),
 	);
-
-	#[cfg(target_os = "macos")]
-	{
-		let java_version = package.java_version.first().unwrap().to_string();
-		base_path = base_path.join(format!("zulu-{java_version}.jre"));
-	}
 
 	base_path = base_path.join(get_java_bin());
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,11 @@ packages:
   - packages/*
   - .github/actions/*
 
+allowBuilds:
+  '@tailwindcss/oxide': true
+  esbuild: true
+  unrs-resolver: true
+
 catalog:
   tsx: ^4.19.4
   typescript: ^5.8.3


### PR DESCRIPTION
so oneclient doesnt have a macos version at all rn. this pr adds the whole thing to make it work on mac.

**1. java detection was completely broken**
the macos version of `internal_locate_java` used `.join(get_java_bin())` which slaps `Contents/Home/bin/java` onto paths that either already have `java` directly (like the JavaVM framework Commands dir) or already point at a JDK home. so nothing was ever found. also didnt scan `/Library/Java/JavaVirtualMachines/` at all — which is where literally every normal macOS JDK install lives.

replaced with actual path scanning: /Library/Java/JavaVirtualMachines/*.jdk, the JavaVM framework stub, the Internet Plug-Ins JRE, and SDKMAN if u use it.

**2. java auto-install path was wrong**
in `install_java_package` there's a macos-only block that adds `zulu-{version}.jre` between the extracted zip dir and `Contents/Home/bin/java`. but azul zulu jre archives extract directly without that wrapper. so the binary could never be found after download, chmod never ran on the real file, and u get "failed to execute java command".

just removed the extra dir segment.

**3. dyld_fallback_library_path was only cleaned in debug mode**
`DYLD_FALLBACK_LIBRARY_PATH` messes with lwjgl loading its native libs (openal, etc). the code only removed it when `CARGO` env var was set (debug/dev). in release builds it just leaked through. made it unconditional on macos.

tested on macos 26.3.1 aarch64, app launches, jdk detection works, auto-download works, minecraft launches. should be gtg