### PR TITLE
Fix/macos java detection install path

### DIFF
--- a/packages/core/src/api/game/launch.rs
+++ b/packages/core/src/api/game/launch.rs
@@ -199,8 +199,11 @@ pub async fn launch_minecraft(
 		})
 	});
 
+	// On macOS, always remove DYLD_FALLBACK_LIBRARY_PATH which can interfere with
+	// LWJGL native library loading for OpenAL and other native libraries.
+	// This is necessary for both debug (cargo sets it) and release builds.
 	#[cfg(target_os = "macos")]
-	if std::env::var("CARGO").is_ok() {
+	{
 		command.env_remove("DYLD_FALLBACK_LIBRARY_PATH");
 	}
 

--- a/packages/core/src/api/java/mod.rs
+++ b/packages/core/src/api/java/mod.rs
@@ -308,23 +308,55 @@ fn internal_locate_java() -> Vec<PathBuf> {
 fn internal_locate_java() -> Vec<PathBuf> {
 	let mut found = Vec::new();
 
-	// TODO(macos): More paths for Java installations
+	// Standard macOS JDK location: /Library/Java/JavaVirtualMachines/*.jdk/Contents/Home/bin/java
+	if let Ok(entries) = std::fs::read_dir("/Library/Java/JavaVirtualMachines") {
+		for entry in entries.flatten() {
+			let java_bin = entry
+				.path()
+				.join("Contents")
+				.join("Home")
+				.join("bin")
+				.join(JAVA_BIN);
+			if java_bin.exists() {
+				found.push(java_bin);
+			}
+		}
+	}
 
-	let paths = vec![
-		r"/System/Library/Frameworks/JavaVM.framework/Versions/Current/Commands",
-		r"/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/MacOS/itms/java",
-		r"/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home",
-	];
+	// System Java VM framework /usr/bin/java (the Apple-provided stub)
+	let sys_java = PathBuf::from(
+		"/System/Library/Frameworks/JavaVM.framework/Versions/Current/Commands",
+	)
+	.join(JAVA_BIN);
+	if sys_java.exists() {
+		found.push(sys_java);
+	}
 
-	for path in paths {
-		let path = PathBuf::from(path).join(get_java_bin());
-		if path.exists() {
-			found.push(path);
+	// Java Applet Plugin (JRE)
+	let plugin_java = PathBuf::from(
+		"/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home",
+	)
+	.join("bin")
+	.join(JAVA_BIN);
+	if plugin_java.exists() {
+		found.push(plugin_java);
+	}
+
+	// SDKMAN installations
+	if let Ok(home) = std::env::var("HOME") {
+		let sdkman_dir =
+			PathBuf::from(home).join(".sdkman").join("candidates").join("java");
+		if let Ok(entries) = std::fs::read_dir(sdkman_dir) {
+			for entry in entries.flatten() {
+				let java_bin = entry.path().join("bin").join(JAVA_BIN);
+				if java_bin.exists() {
+					found.push(java_bin);
+				}
+			}
 		}
 	}
 
 	found = find_java_in_path(found);
-
 	found
 }
 
@@ -449,12 +481,6 @@ pub async fn install_java_package(package: &JavaPackage) -> LauncherResult<PathB
 			.to_string_lossy()
 			.to_string(),
 	);
-
-	#[cfg(target_os = "macos")]
-	{
-		let java_version = package.java_version.first().unwrap().to_string();
-		base_path = base_path.join(format!("zulu-{java_version}.jre"));
-	}
 
 	base_path = base_path.join(get_java_bin());
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,11 @@ packages:
   - packages/*
   - .github/actions/*
 
+allowBuilds:
+  '@tailwindcss/oxide': true
+  esbuild: true
+  unrs-resolver: true
+
 catalog:
   tsx: ^4.19.4
   typescript: ^5.8.3


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail along with its rationale --> so oneclient doesnt have a macos version at all rn, this pr adds the whole thing to make it work on mac.

## Related Issue(s)

<!-- List the issue(s) this PR solves, if any -->
Fixes # n/a

## How to test

<!-- Provide steps to test this PR --> 
1. build on an apple silicon mac: `cd apps/oneclient/desktop && pnpm tauri build --bundles app,dmg`
2. open the .app or install the .dmg
3. launch minecraft through the app — it should find any jdks in /Library/Java/JavaVirtualMachines/ or auto-download one if none exist
4. game should launch without "failed to execute java command" errors

## Documentation

<!--
Does this PR require updates to the documentation at docs.polyfrost.org?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/Nexus/issues/new?assignees=&labels=bug&template=new_feature.yml
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility at https://contributing.polyfrost.org/)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
--> n/a
