### PR TITLE
Fix/refreshing account doesnt change username

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# Linux and Macos by default have 8MB of stack storage.
+# Windows has 1MB, it isn't enough, so it's changed to 8MB also.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=/STACK:8388608"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=/STACK:8388608"]

--- a/packages/oneclient_auth/src/msa.rs
+++ b/packages/oneclient_auth/src/msa.rs
@@ -353,7 +353,6 @@ pub async fn refresh_microsoft_account(
     let msa = refresh_msa_token(client, &creds.refresh_token).await?;
     let mut account = account_from_msa_token(client, msa, |_, _, _| {}).await?;
     account.id = creds.id;
-    account.username = creds.username.clone();
     Ok(account)
 }
 


### PR DESCRIPTION
## Description

While refreshing account, username was always being set to the old account data. Removed it and now username refreshes properly.

## Related Issue(s)

https://github.com/Polyfrost/OneLauncher/issues/712

## How to test

1. Open up OneClient
2. Change your minecraft username on microsoft website
3. Refresh the account in account settings in OneClient
4. Now username should be the newly set username

## Documentation

No