### PR TITLE
feat: added rerendering after every new java runtime addition

### DIFF
--- a/packages/oneclient_app/src/hooks/actions.rs
+++ b/packages/oneclient_app/src/hooks/actions.rs
@@ -20,7 +20,7 @@ use oneclient_events::{Answer, Level};
 use tokio::sync::mpsc;
 
 use crate::components::IconType;
-use crate::launcher;
+use crate::{invalidate_java_queries, launcher};
 use crate::notifications::{
     ClusterUpdateSummary, NotificationAction, NotificationSpec, PackageUpdateGroup, PendingPrompt,
 };
@@ -438,7 +438,10 @@ impl Actions {
             let Ok(state) = launcher::state() else { return };
             let events = state.services.events.clone();
             match state.java.install_runtime_from(&vendor, major).await {
-                Ok(_) => events.signal(oneclient_events::Signal::JavaChanged),
+                Ok(_) => {
+                    events.signal(oneclient_events::Signal::JavaChanged);
+                    invalidate_java_queries().await
+                },
                 Err(err) => events
                     .notify("Java install failed")
                     .body(err.to_string())

--- a/packages/oneclient_app/src/view/app/settings/java.rs
+++ b/packages/oneclient_app/src/view/app/settings/java.rs
@@ -4,6 +4,7 @@ use oneclient_java::{JavaRuntime, JavaVendor};
 use super::settings_page;
 use crate::components::{Button, Icon, IconType, JavaInstallManager, ScrollArea};
 use crate::hooks::{Actions, java_runtimes, use_dispatch, use_java_runtimes};
+use crate::invalidate_java_queries;
 use crate::theme::colors;
 use crate::ui::border_all_color;
 use crate::view::app::settings::section_header;
@@ -18,10 +19,40 @@ impl Component for SettingsJava {
         let runtimes = java_runtimes(&runtimes_query);
         let mut show_manager = use_state(|| false);
 
+        fn invalidate_runtimes(dispatch: Actions) {
+            spawn(async move {
+                invalidate_java_queries().await;
+                dispatch
+                    .notify("Java runtimes refreshed")
+                    .body("The installed runtime list is up to date")
+                    .info()
+                    .send();
+            });
+        }
+
+        let refresh_dispatch = dispatch.clone();
+
         let mut shell = settings_page()
             .child(section_header("ADD RUNTIME"))
             .child(AddRow { show_manager }.into_element())
-            .child(section_header("INSTALLED RUNTIMES"))
+            .child(
+                rect()
+                    .width(Size::Fill)
+                    .direction(Direction::Horizontal)
+                    .main_align(Alignment::SpaceBetween)
+                    .cross_align(Alignment::Center)
+                    .child(section_header("INSTALLED RUNTIMES"))
+                    .child(
+                        Button::new()
+                            .secondary()
+                            .small()
+                            .enabled(false) // disabled for now
+                            .on_press(move |_| {
+                                invalidate_runtimes(refresh_dispatch.clone());
+                            })
+                            .child(label().text("Refresh"))
+                    )
+            )
             .child(runtimes_table(runtimes));
 
         if *show_manager.read() {

--- a/packages/oneclient_java/src/install.rs
+++ b/packages/oneclient_java/src/install.rs
@@ -67,6 +67,7 @@ pub async fn install_package(
 	if let Some(child) = &child {
 		child.set_phase(TaskPhase::Extracting);
 	}
+	//events.notify("Extracting package...").body(format!("{} {}", package.vendor, major)).send();
 
 	match package.archive {
 		PackageArchive::Zip => polyio::extract_zip(&archive_path, &extract_root).await?,

--- a/packages/oneclient_java/src/service.rs
+++ b/packages/oneclient_java/src/service.rs
@@ -222,13 +222,29 @@ impl JavaService {
 		vendor: &JavaVendor,
 		major: u32,
 	) -> JavaResult<JavaRuntime> {
+		self.install_vendor_runtime(vendor, major, None).await
+	}
+
+	#[tracing::instrument(level = "debug", skip(self, progress))]
+	async fn install_vendor_runtime(
+		&self,
+		vendor: &JavaVendor,
+		major: u32,
+		progress: Option<&GroupedProgressSession>,
+	) -> JavaResult<JavaRuntime> {
 		let provider = provider_for_vendor(vendor).ok_or(JavaError::PackageNotFound { major })?;
 		let package = provider
 			.latest_package_by_major(major, &self.net)
 			.await?
 			.ok_or(JavaError::PackageNotFound { major })?;
+
+		let owned = progress.is_none().then(|| {
+			GroupedProgressSession::start(&self.events, format!("Installing Java {major}"))
+		});
+		let session = progress.or(owned.as_ref()).expect("session present");
+
 		let executable = provider
-			.install_package(&package, &self.net, &self.events, None)
+			.install_package(&package, &self.net, &self.events, Some(session))
 			.await?;
 
 		self.register_checked(&executable, Some(major)).await
@@ -265,7 +281,7 @@ impl JavaService {
 				Some(vendor) => {
 					let vendor = JavaVendor::from_str(vendor)
 						.unwrap_or_else(|_| JavaVendor::Other(vendor.to_string()));
-					self.install_runtime_from(&vendor, major).await
+					self.install_vendor_runtime(&vendor, major, progress).await
 				}
 				None => self.download_and_register(major, progress).await,
 			},


### PR DESCRIPTION
## Description

Added invalidating java queries everytime new java runtime has been downloaded.
- Java runtimes list wasn't being rerendered when new runtime has been added.

Changed the toast to track file unpacking progress on top of downloading package from provider.
- Toast was done too quickly, after downloading the package from provider it was finished. There was a gap, where package was downloaded, but it wasn't unpacked, so the user was left with no feedback.

Added manual refresh button, but for now it's disabled.

## Related Issue(s)

https://github.com/Polyfrost/OneLauncher/issues/710

## How to test

1. Open Java settings in OneClient
2. Download any java runtime
3. Wait for it to download (new toast)
4. After toast says the process finished, view is being rerendered showing new java runtime as a row.

## Documentation

No
