### PR TITLE
feat: don't show again prompt

### DIFF
--- a/packages/oneclient_app/src/components/checkbox.rs
+++ b/packages/oneclient_app/src/components/checkbox.rs
@@ -1,0 +1,199 @@
+#![allow(dead_code)]
+use freya::{
+    animation::{AnimColor, AnimNum, AnimatedValue, Ease, Function, use_animation_transition},
+    prelude::*,
+};
+
+use crate::{
+    components::{Icon, IconType},
+    theme::colors,
+    ui,
+};
+
+const BOX_SIZE: f32 = 18.;
+const MARK_SIZE: f32 = 12.;
+const TIME: u64 = 180;
+
+pub fn checkbox(value: State<bool>) -> impl IntoElement {
+    let mut v = value;
+    Check {
+        value,
+        label: None,
+        on_press: (move |()| v.toggle()).into(),
+        disabled: false,
+    }
+}
+
+pub fn checkbox_labeled(value: State<bool>, text: impl Into<Box<str>>) -> impl IntoElement {
+    let mut v = value;
+    Check {
+        value,
+        label: Some(text.into()),
+        on_press: (move |()| v.toggle()).into(),
+        disabled: false,
+    }
+}
+
+pub fn checkbox_disabled(value: State<bool>) -> impl IntoElement {
+    Check {
+        value,
+        label: None,
+        on_press: (|()| {}).into(),
+        disabled: true,
+    }
+}
+
+pub fn checkbox_controlled(checked: bool, on_toggle: EventHandler<()>) -> CheckboxControlled {
+    CheckboxControlled {
+        checked,
+        label: None,
+        on_toggle,
+    }
+}
+
+pub fn checkbox_controlled_labeled(
+    checked: bool,
+    text: impl Into<Box<str>>,
+    on_toggle: EventHandler<()>,
+) -> CheckboxControlled {
+    CheckboxControlled {
+        checked,
+        label: Some(text.into()),
+        on_toggle,
+    }
+}
+
+#[derive(PartialEq)]
+pub struct CheckboxControlled {
+    checked: bool,
+    label: Option<Box<str>>,
+    on_toggle: EventHandler<()>,
+}
+
+impl Component for CheckboxControlled {
+    fn render(&self) -> impl IntoElement {
+        let mut value = use_state(|| self.checked);
+        value.set_if_modified(self.checked);
+        Check {
+            value,
+            label: self.label.clone(),
+            on_press: self.on_toggle.clone(),
+            disabled: false,
+        }
+    }
+}
+
+#[derive(PartialEq)]
+struct Check {
+    value: State<bool>,
+    label: Option<Box<str>>,
+    on_press: EventHandler<()>,
+    disabled: bool,
+}
+
+impl Component for Check {
+    fn render(&self) -> impl IntoElement {
+        let value = self.value;
+        let on_press = self.on_press.clone();
+        let checked = *value.read();
+        let disabled = self.disabled;
+
+        let a11y_id = use_a11y();
+        let focus = use_focus(a11y_id);
+
+        let box_border = if focus().is_focused() && !disabled {
+            colors::fg_primary()
+        } else if checked && !disabled {
+            colors::brand()
+        } else {
+            colors::component_border()
+        };
+
+        let background = use_animation_transition(value, |_, checked| {
+            if checked {
+                AnimColor::new(colors::component_bg(), colors::brand())
+            } else {
+                AnimColor::new(colors::brand(), colors::component_bg())
+            }
+            .time(TIME)
+            .function(Function::Expo)
+            .ease(Ease::Out)
+        });
+
+        let mark = use_animation_transition(value, |_, checked| {
+            let scale = AnimNum::new(0.5, 1.)
+                .time(TIME)
+                .function(Function::Expo)
+                .ease(Ease::Out);
+            let opacity = AnimNum::new(0., 1.)
+                .time(TIME)
+                .function(Function::Expo)
+                .ease(Ease::Out);
+
+            if checked {
+                (scale, opacity)
+            } else {
+                (scale.into_reversed(), opacity.into_reversed())
+            }
+        });
+
+        let (mark_scale, mark_opacity) = {
+            let mark = mark.read();
+            (mark.0.value(), mark.1.value())
+        };
+
+        use_drop(|| {
+            Cursor::set(CursorIcon::default());
+        });
+
+        rect()
+            .horizontal()
+            .cross_align(Alignment::Center)
+            .spacing(8.)
+            .a11y_id(a11y_id)
+            .a11y_focusable(!disabled)
+            .a11y_role(AccessibilityRole::CheckBox)
+            .maybe(!disabled, |el| {
+                el.on_pointer_enter(|_| Cursor::set(CursorIcon::Pointer))
+                    .on_pointer_leave(|_| Cursor::set(CursorIcon::default()))
+                    .on_all_press(move |_| {
+                        on_press.call(());
+                    })
+            })
+            .child(
+                rect()
+                    .width(Size::px(BOX_SIZE))
+                    .height(Size::px(BOX_SIZE))
+                    .corner_radius(CornerRadius::new_all(5.))
+                    .main_align(Alignment::Center)
+                    .cross_align(Alignment::Center)
+                    .background(if disabled {
+                        colors::component_bg_disabled()
+                    } else {
+                        background.read().value()
+                    })
+                    .border(ui::border_all_color(1., box_border))
+                    .maybe_child((checked || mark_opacity > 0.).then(|| {
+                        rect().opacity(mark_opacity).scale(mark_scale).child(
+                            Icon::new(IconType::Check)
+                                .size(MARK_SIZE)
+                                .color(if disabled {
+                                    colors::fg_secondary()
+                                } else {
+                                    Color::WHITE
+                                }),
+                        )
+                    })),
+            )
+            .maybe_child(self.label.as_ref().map(|text| {
+                label()
+                    .text(text.to_string())
+                    .font_size(12.)
+                    .color(if disabled {
+                        colors::fg_secondary()
+                    } else {
+                        colors::fg_primary()
+                    })
+            }))
+    }
+}

--- a/packages/oneclient_app/src/components/mod.rs
+++ b/packages/oneclient_app/src/components/mod.rs
@@ -3,6 +3,7 @@ mod active_cluster_panel;
 mod avatar;
 mod button;
 mod charts;
+mod checkbox;
 mod cluster_landscape_art;
 mod cluster_update_popup;
 mod context_menu;
@@ -42,6 +43,10 @@ pub use active_cluster_panel::ActiveClusterPanel;
 pub use avatar::Avatar;
 pub use button::{Button, ButtonSize, ButtonVariant, link_button, open_folder_button};
 pub use charts::{BarChart, PieChart, ValueUnit, slice_color};
+#[allow(unused_imports)]
+pub use checkbox::{
+    checkbox, checkbox_controlled, checkbox_controlled_labeled, checkbox_disabled, checkbox_labeled,
+};
 pub use cluster_landscape_art::ClusterLandscapeArt;
 pub use cluster_update_popup::ClusterUpdatePopup;
 pub use context_menu::ContextMenu;

--- a/packages/oneclient_app/src/components/package_update_popup.rs
+++ b/packages/oneclient_app/src/components/package_update_popup.rs
@@ -3,11 +3,14 @@
 use std::collections::HashMap;
 
 use freya::prelude::*;
+use oneclient_common::{PackageUpdateMode, Patch};
 use oneclient_content::packages::{CachedPackageMeta, ProviderId};
-use oneclient_core::BrowserPackageUpdate;
+use oneclient_core::{BrowserPackageUpdate, ProfileUpdate};
 use oneclient_db::models::ClusterId;
+use skia_safe::utils::text_utils::Align;
 
-use crate::components::{Button, Dropdown, Icon, IconType, OverlayPopup, ScrollArea};
+use crate::components::toggle::ToggleControlled;
+use crate::components::{Button, Dropdown, Icon, IconType, OverlayPopup, ScrollArea, checkbox, checkbox_labeled, toggle_controlled};
 use crate::hooks::{
     package_meta_batch, use_dispatch, use_notifications_snapshot, use_package_meta_batch,
 };
@@ -65,6 +68,37 @@ impl Component for PackageUpdatePopup {
         let choices = use_state(HashMap::<RowKey, RowChoice>::new);
 
         let groups = snapshot.package_updates.clone();
+
+        // let groups = Some(vec![PackageUpdateGroup {
+        //     cluster_id: 1,
+        //     cluster_name: "Debug Cluster".to_string(),
+        //     packages: vec![
+        //         BrowserPackageUpdate {
+        //             cluster_id: 1,
+        //             hash: "fake-hash-1".to_string(),
+        //             provider: ProviderId::Local,
+        //             project_id: "fake-1".to_string(),
+        //             installed_version_id: "1".to_string(),
+        //             installed_version_name: "1.0.0".to_string(),
+        //             latest_version_id: "2".to_string(),
+        //             latest_version_name: "1.1.0".to_string(),
+        //             display_name: "Sodium".to_string(),
+        //             skipped: false,
+        //         },
+        //         BrowserPackageUpdate {
+        //             cluster_id: 1,
+        //             hash: "fake-hash-2".to_string(),
+        //             provider: ProviderId::Local,
+        //             project_id: "fake-2".to_string(),
+        //             installed_version_id: "3".to_string(),
+        //             installed_version_name: "0.9.1".to_string(),
+        //             latest_version_id: "4".to_string(),
+        //             latest_version_name: "1.0.0".to_string(),
+        //             display_name: "Iris Shaders".to_string(),
+        //             skipped: false,
+        //         },
+        //     ],
+        // }]);
 
         // Hooks run unconditionally so this must precede the early return below
         let mut meta = MetaMap::new();
@@ -141,7 +175,10 @@ fn content(
 ) -> impl IntoElement {
     let dismiss = dispatch.clone();
     let proceed_dispatch = dispatch.clone();
+    let dsa_dispatch = dispatch.clone();
     let total: usize = groups.iter().map(|group| group.packages.len()).sum();
+
+    let dont_show_again = use_state(|| false);
 
     let subtitle = match groups {
         [only] => format!(
@@ -194,40 +231,67 @@ fn content(
                 .horizontal()
                 .width(Size::fill())
                 .cross_align(Alignment::Center)
-                .main_align(Alignment::End)
+                .main_align(Alignment::SpaceBetween)
                 .spacing(8.)
                 .child(
-                    Button::new()
-                        .ghost()
-                        .on_press(move |_| dismiss.close_package_updates())
-                        .text("Cancel"),
+                    rect()
+                        .direction(Direction::Horizontal)
+                        .main_align(Alignment::Start)
+                        .cross_align(Alignment::Center)
+                        .spacing(6.)
+                        .child(
+                            checkbox_labeled(dont_show_again, "Don't show again?")
+                        )
                 )
                 .child(
-                    Button::new()
-                        .primary()
-                        .on_press(move |_| {
-                            let answers = choices.read();
-                            for update in &all {
-                                match answers
-                                    .get(&row_key(update))
-                                    .copied()
-                                    .unwrap_or_default()
-                                {
-                                    RowChoice::Update => {
-                                        proceed_dispatch.apply_package_update(update.clone());
+                    rect()
+                        .width(Size::fill())
+                        .direction(Direction::Horizontal)
+                        .cross_align(Alignment::Center)
+                        .main_align(Alignment::End)
+                        .child(
+                            Button::new()
+                                .ghost()
+                                .on_press(move |_| dismiss.close_package_updates())
+                                .text("Cancel"),
+                        )
+                        .child(
+                            Button::new()
+                                .primary()
+                                .on_press(move |_| {
+                                    let choice = match *dont_show_again.peek() {
+                                        true => PackageUpdateMode::Automatic,
+                                        false => PackageUpdateMode::Prompt,
+                                    };
+
+                                    dsa_dispatch.update_global_profile(ProfileUpdate {
+                                        browser_update_mode: Patch::Set(choice),
+                                        ..Default::default()
+                                    });
+
+                                    let answers = choices.read();
+                                    for update in &all {
+                                        match answers
+                                            .get(&row_key(update))
+                                            .copied()
+                                            .unwrap_or_default()
+                                        {
+                                            RowChoice::Update => {
+                                                proceed_dispatch.apply_package_update(update.clone());
+                                            }
+                                            RowChoice::Skip => {}
+                                            RowChoice::SkipVersion => proceed_dispatch
+                                                .skip_package_update(
+                                                    update.cluster_id,
+                                                    update.hash.clone(),
+                                                ),
+                                        }
                                     }
-                                    RowChoice::Skip => {}
-                                    RowChoice::SkipVersion => proceed_dispatch
-                                        .skip_package_update(
-                                            update.cluster_id,
-                                            update.hash.clone(),
-                                        ),
-                                }
-                            }
-                            proceed_dispatch.close_package_updates();
-                        })
-                        .child(Icon::new(IconType::DownloadCloud02).size(15.))
-                        .text("Proceed"),
+                                    proceed_dispatch.close_package_updates();
+                                })
+                                .child(Icon::new(IconType::DownloadCloud02).size(15.))
+                                .text("Proceed"),
+                        )
                 ),
         )
 }

--- a/packages/oneclient_app/src/components/package_update_popup.rs
+++ b/packages/oneclient_app/src/components/package_update_popup.rs
@@ -69,37 +69,6 @@ impl Component for PackageUpdatePopup {
 
         let groups = snapshot.package_updates.clone();
 
-        // let groups = Some(vec![PackageUpdateGroup {
-        //     cluster_id: 1,
-        //     cluster_name: "Debug Cluster".to_string(),
-        //     packages: vec![
-        //         BrowserPackageUpdate {
-        //             cluster_id: 1,
-        //             hash: "fake-hash-1".to_string(),
-        //             provider: ProviderId::Local,
-        //             project_id: "fake-1".to_string(),
-        //             installed_version_id: "1".to_string(),
-        //             installed_version_name: "1.0.0".to_string(),
-        //             latest_version_id: "2".to_string(),
-        //             latest_version_name: "1.1.0".to_string(),
-        //             display_name: "Sodium".to_string(),
-        //             skipped: false,
-        //         },
-        //         BrowserPackageUpdate {
-        //             cluster_id: 1,
-        //             hash: "fake-hash-2".to_string(),
-        //             provider: ProviderId::Local,
-        //             project_id: "fake-2".to_string(),
-        //             installed_version_id: "3".to_string(),
-        //             installed_version_name: "0.9.1".to_string(),
-        //             latest_version_id: "4".to_string(),
-        //             latest_version_name: "1.0.0".to_string(),
-        //             display_name: "Iris Shaders".to_string(),
-        //             skipped: false,
-        //         },
-        //     ],
-        // }]);
-
         // Hooks run unconditionally so this must precede the early return below
         let mut meta = MetaMap::new();
         for provider in ProviderId::REMOTE_PROVIDERS.iter().copied() {

--- a/packages/oneclient_core/examples/launch_game.rs
+++ b/packages/oneclient_core/examples/launch_game.rs
@@ -9,7 +9,7 @@ use oneclient_common::domain::GameLoader;
 async fn main() -> LauncherResult<()> {
     dev::initialize().await?;
     let state = dev::ephemeral_state().await?;
-
+    
     let args: Vec<String> = std::env::args().skip(1).collect();
     let mc_version = args.first().map(String::as_str).unwrap_or("1.21.4");
     let loader = args

--- a/packages/oneclient_core/examples/launch_game.rs
+++ b/packages/oneclient_core/examples/launch_game.rs
@@ -9,7 +9,7 @@ use oneclient_common::domain::GameLoader;
 async fn main() -> LauncherResult<()> {
     dev::initialize().await?;
     let state = dev::ephemeral_state().await?;
-    
+
     let args: Vec<String> = std::env::args().skip(1).collect();
     let mc_version = args.first().map(String::as_str).unwrap_or("1.21.4");
     let loader = args


### PR DESCRIPTION
## Description

1. Added a checkbox component (couldn't find one inside the codebase)
2. Added "Don't show again?" prompt to the package update modal

## Related Issue(s)

https://github.com/Polyfrost/OneLauncher/issues/656

## How to test

1. Enter into OneClient with an outdated mod, a package update modal should pop up
2. Click "Don't show again?" checkbox.
3. In the Minecraft Settings inside OneClient look for "Browser Package Updates", now it should be "Automatically update".
4. If you won't check the checkbox, it'll stay/change into "Show modal".

## Documentation

No