### PR TITLE
Fix settings back button navigation

### DIFF
--- a/packages/oneclient_app/src/layout/animated_outlet.rs
+++ b/packages/oneclient_app/src/layout/animated_outlet.rs
@@ -65,8 +65,19 @@ impl Component for AnimatedAppOutlet {
     fn render(&self) -> impl IntoElement {
         let mut router = use_animated_router::<Route>();
 
-        let history = use_previous_and_current(use_route::<Route>());
-        let back_title = history.read().0.title();
+        let route = use_route::<Route>();
+        let mut origin_route = use_state(|| route.clone());
+        let mut last_route = use_state(|| route.clone());
+
+        use_side_effect_with_deps(&route, move |current| {
+            let prev = last_route.peek().clone();
+            if !(is_sidebar_route(&prev) && is_sidebar_route(current)) {
+                origin_route.set(prev);
+            }
+            last_route.set(current.clone());
+        });
+
+        let back_title = origin_route.read().title();
 
         let anim = use_animation(|_conf| {
             AnimNum::new(0., 1.)

--- a/packages/oneclient_app/src/layout/settings_shell.rs
+++ b/packages/oneclient_app/src/layout/settings_shell.rs
@@ -204,8 +204,7 @@ const SEARCH_INDEX: &[SearchItem] = &[
         title: "Free up space",
         description: "Remove cached packages and leftovers nothing is using.",
         keywords: &[
-            "storage", "clean", "cleanup", "free", "space", "cache", "unused", "orphan",
-            "leftover",
+            "storage", "clean", "cleanup", "free", "space", "cache", "unused", "orphan", "leftover",
         ],
         route: Route::SettingsStorage {},
     },
@@ -576,7 +575,7 @@ fn search_results(query: &SearchQuery, mut search: State<String>) -> Vec<Element
                 .on_press(move |_| {
                     set_pending_setting_focus(id);
                     search.set(String::new());
-                    let _ = RouterContext::get().push(route.clone());
+                    let _ = RouterContext::get().replace(route.clone());
                 })
                 .child(Icon::new(item.icon))
                 .child(
@@ -808,7 +807,7 @@ impl Component for SidebarItem {
             })
             .map(route, |el, route| {
                 el.on_all_press(move |_| {
-                    let _ = RouterContext::get().push(route.clone());
+                    let _ = RouterContext::get().replace(route.clone());
                 })
             });
 


### PR DESCRIPTION
Fixes #715

## Changes

- Use `replace()` instead of `push()` when navigating between Settings pages so tabs don't accumulate in router history.
- Preserve the original route for the Settings back button.
- The Back button now returns directly to the screen from which Settings was opened.

## Testing

- Manually tested navigation through multiple Settings pages.
- Verified Back returns directly to the original screen.
- `cargo test -p oneclient_app` — 59 passed.
- `cargo clippy -p oneclient_app --all-targets` — passed.
- `git diff --check` — passed.