### PR TITLE
feat: added context menu on homepage clusters

### DIFF
--- a/packages/oneclient_app/src/components/context_menu.rs
+++ b/packages/oneclient_app/src/components/context_menu.rs
@@ -18,9 +18,22 @@ enum Entry {
     Separator,
 }
 
+fn separator(item_width: Option<f32>) -> Rect {
+    let mut sep = rect()
+        .height(Size::px(1.))
+        .margin(Gaps::new_symmetric(4., 0.))
+        .background(MENU_BORDER);
+    if let Some(w) = item_width {
+        sep = sep.width(Size::px(w));
+    }
+    sep
+}
+
 pub struct ContextMenu {
     x: f32,
     y: f32,
+    upwards: bool,
+    title: Option<String>,
     entries: Vec<Entry>,
     on_close: EventHandler<()>,
 }
@@ -30,9 +43,21 @@ impl ContextMenu {
         Self {
             x,
             y,
+            upwards: false,
+            title: None,
             entries: Vec::new(),
             on_close: (|()| {}).into(),
         }
+    }
+
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    pub fn open_upwards(mut self) -> Self {
+        self.upwards = true;
+        self
     }
 
     pub fn on_close(mut self, on_close: impl Into<EventHandler<()>>) -> Self {
@@ -78,7 +103,6 @@ impl ContextMenu {
 
 impl PartialEq for ContextMenu {
     fn eq(&self, _other: &Self) -> bool {
-        // Always unequal the menu is rebuilt from scratch whenever it is reopened
         false
     }
 }
@@ -88,6 +112,7 @@ impl Component for ContextMenu {
         let on_close = self.on_close.clone();
 
         let mut width = use_state(|| 0f32);
+        let mut height = use_state(|| 0f32);
 
         let item_width = {
             let w = *width.read();
@@ -95,18 +120,26 @@ impl Component for ContextMenu {
         };
 
         let mut list = rect().vertical().spacing(4.);
+
+        if let Some(title) = &self.title {
+            list = list
+                .child(
+                    // Asymmetric on purpose
+                    rect().padding(Gaps::new(6., 8., 4., 8.)).child(
+                        label()
+                            .text(title.clone())
+                            .font_size(11.)
+                            .font_weight(FontWeight::SEMI_BOLD)
+                            .max_lines(1)
+                            .color(colors::fg_secondary()),
+                    ),
+                )
+                .child(separator(item_width));
+        }
+
         for entry in &self.entries {
             list = match entry {
-                Entry::Separator => {
-                    let mut sep = rect()
-                        .height(Size::px(1.))
-                        .margin(Gaps::new_symmetric(4., 0.))
-                        .background(MENU_BORDER);
-                    if let Some(w) = item_width {
-                        sep = sep.width(Size::px(w));
-                    }
-                    list.child(sep)
-                }
+                Entry::Separator => list.child(separator(item_width)),
                 Entry::Action {
                     icon,
                     label,
@@ -133,6 +166,11 @@ impl Component for ContextMenu {
             }
         });
 
+        let measured = *height.read();
+        let flips = self.upwards && measured > 0. && self.y - measured >= 0.;
+        let top = if flips { self.y - measured } else { self.y };
+        let placed = !self.upwards || measured > 0.;
+
         let panel = rect()
             .vertical()
             .padding(Gaps::new_all(6.))
@@ -144,11 +182,18 @@ impl Component for ContextMenu {
                 bottom: 1.,
                 left: 1.,
             }))
+            .opacity(if placed { 1. } else { 0. })
+            .on_sized(move |e: Event<SizedEventData>| {
+                let measured = e.data().area.height();
+                if (measured - *height.peek()).abs() > 0.5 {
+                    height.set(measured);
+                }
+            })
             .child(list);
 
         OverlayPopup::new()
-            .backdrop(false)
-            .position(Position::new_global().top(self.y).left(self.x))
+            .backdrop(true)
+            .position(Position::new_global().top(top).left(self.x))
             .on_close(move |_| on_close.call(()))
             .child(panel.into_element())
     }

--- a/packages/oneclient_app/src/components/recents_row.rs
+++ b/packages/oneclient_app/src/components/recents_row.rs
@@ -3,7 +3,7 @@ use freya::prelude::*;
 use freya::router::RouterContext;
 use oneclient_core::clusters::Cluster;
 
-use crate::components::{ART_PREVIEW_EDGE, DynamicArt, Icon, IconType};
+use crate::components::{ART_PREVIEW_EDGE, ContextMenu, DynamicArt, Icon, IconType};
 use crate::hooks::{settled_or_loading, use_active_cluster_id, use_clusters};
 use crate::routes::Route;
 use crate::theme::colors;
@@ -93,6 +93,46 @@ fn stagger_eased(progress: f32, index: usize, items: usize) -> f32 {
     1.0 - (1.0 - local).powi(3)
 }
 
+fn cluster_menu_entries(cluster_id: i64) -> [(IconType, &'static str, Route); 7] {
+    [
+        (
+            IconType::InfoCircle,
+            "Overview",
+            Route::ClusterOverview { cluster_id },
+        ),
+        (
+            IconType::Terminal,
+            "Logs",
+            Route::ClusterLogs { cluster_id },
+        ),
+        (
+            IconType::Eye,
+            "Screenshots",
+            Route::ClusterScreenshots { cluster_id },
+        ),
+        (
+            IconType::CodeSnippet02,
+            "Mods",
+            Route::ClusterMods { cluster_id },
+        ),
+        (
+            IconType::PaintPour,
+            "Shaders",
+            Route::ClusterShaders { cluster_id },
+        ),
+        (
+            IconType::Colors,
+            "Textures",
+            Route::ClusterTextures { cluster_id },
+        ),
+        (
+            IconType::Settings01,
+            "Settings",
+            Route::ClusterSettings { cluster_id },
+        ),
+    ]
+}
+
 struct ClusterCard {
     cluster: Cluster,
     index: usize,
@@ -114,6 +154,7 @@ impl Component for ClusterCard {
         let mut active_id = use_active_cluster_id();
         let active = *active_id.read() == Some(self.cluster.id);
         let mut hovering = use_state(|| false);
+        let mut menu = use_state(|| None::<(f32, f32)>);
 
         let a11y_id = use_a11y();
         let focus = use_focus(a11y_id);
@@ -128,6 +169,19 @@ impl Component for ClusterCard {
         let on_press = move |_| {
             *active_id.write() = Some(cluster_id);
         };
+
+        let menu_overlay = (*menu.read()).map(|(x, y)| {
+            let mut context = ContextMenu::new(x, y)
+                .open_upwards()
+                .title(title.clone())
+                .on_close(move |_| menu.set(None));
+            for (icon, label, route) in cluster_menu_entries(cluster_id) {
+                context = context.action(icon, label, move |()| {
+                    let _ = RouterContext::get().push(route.clone());
+                });
+            }
+            context.into_element()
+        });
 
         rect()
             .key(self.cluster.id)
@@ -172,7 +226,15 @@ impl Component for ClusterCard {
                             .y(0.)
                             .color(Color::from_af32rgb(0.3, 0, 0, 0)),
                     )
-                    .on_all_press(on_press)
+                    .on_press(on_press)
+                    .on_secondary_down(move |e: Event<PressEventData>| {
+                        if let PressEventData::Mouse(m) = e.data() {
+                            menu.set(Some((
+                                m.global_location.x as f32,
+                                m.global_location.y as f32,
+                            )));
+                        }
+                    })
                     .child(
                         rect()
                             .width(Size::fill())
@@ -222,6 +284,7 @@ impl Component for ClusterCard {
                             ),
                     ),
             )
+            .maybe_child(menu_overlay)
     }
 }
 


### PR DESCRIPTION
## Description

Added context menu on right mouse click for clusters on home page.
Also added title option to the context menu

## Related Issue(s)

https://github.com/Polyfrost/OneLauncher/issues/624

## How to test

1. Go to the home page on OneClient
2. Click RMB on any cluster

## Documentation

No
