### PR TITLE
feat: added context menu on rmb inside screenshot viewer

### DIFF
--- a/packages/oneclient_app/src/components/context_menu.rs
+++ b/packages/oneclient_app/src/components/context_menu.rs
@@ -23,6 +23,7 @@ pub struct ContextMenu {
     y: f32,
     entries: Vec<Entry>,
     on_close: EventHandler<()>,
+    overlay_level: Option<u8>,
 }
 
 impl ContextMenu {
@@ -32,11 +33,17 @@ impl ContextMenu {
             y,
             entries: Vec::new(),
             on_close: (|()| {}).into(),
+            overlay_level: None,
         }
     }
 
     pub fn on_close(mut self, on_close: impl Into<EventHandler<()>>) -> Self {
         self.on_close = on_close.into();
+        self
+    }
+
+    pub fn overlay_level(mut self, level: u8) -> Self {
+        self.overlay_level = Some(level);
         self
     }
 
@@ -146,11 +153,16 @@ impl Component for ContextMenu {
             }))
             .child(list);
 
-        OverlayPopup::new()
+        let mut popup = OverlayPopup::new()
             .backdrop(false)
             .position(Position::new_global().top(self.y).left(self.x))
-            .on_close(move |_| on_close.call(()))
-            .child(panel.into_element())
+            .on_close(move |_| on_close.call(()));
+
+        if let Some(level) = self.overlay_level {
+            popup = popup.overlay_level(level);
+        }
+
+        popup.child(panel.into_element())
     }
 }
 

--- a/packages/oneclient_app/src/components/overlay_popup.rs
+++ b/packages/oneclient_app/src/components/overlay_popup.rs
@@ -5,12 +5,16 @@ use freya::{
 
 const SCRIM_ALPHA: f32 = 90.;
 
+/// Overlay level of a top level popup. Its scrim sits two levels below it.
+const BASE_LEVEL: u8 = 12;
+
 #[derive(PartialEq)]
 pub struct OverlayPopup {
     children: Vec<Element>,
     on_close: Option<EventHandler<()>>,
     position: Position,
     backdrop: bool,
+    overlay_level: u8,
     key: DiffKey,
 }
 
@@ -27,12 +31,19 @@ impl OverlayPopup {
             on_close: None,
             position: Position::new_global().top(0.).left(0.),
             backdrop: true,
+            overlay_level: BASE_LEVEL,
             key: DiffKey::None,
         }
     }
 
     pub fn position(mut self, position: Position) -> Self {
         self.position = position;
+        self
+    }
+
+    // has to be raised on top of the ss viewer (previously context menu and image viewer were at the same level)
+    pub fn overlay_level(mut self, level: u8) -> Self {
+        self.overlay_level = level;
         self
     }
 
@@ -83,7 +94,7 @@ impl Component for OverlayPopup {
                     .position(Position::new_global().top(0.).left(0.))
                     .width(Size::window_percent(100.))
                     .height(Size::window_percent(100.))
-                    .layer(Layer::OverlayLevel(10))
+                    .layer(Layer::OverlayLevel(self.overlay_level.saturating_sub(2)))
                     .background(Color::from_argb(alpha, 0, 0, 0))
                     .on_press(move |_| {
                         if let Some(on_close) = scrim_close.as_ref() {
@@ -98,7 +109,7 @@ impl Component for OverlayPopup {
                     .a11y_focusable(true)
                     .a11y_auto_focus(true)
                     .a11y_role(AccessibilityRole::Dialog)
-                    .layer(Layer::OverlayLevel(12))
+                    .layer(Layer::OverlayLevel(self.overlay_level))
                     .on_global_key_down(move |e: Event<KeyboardEventData>| {
                         if e.key == Key::Named(NamedKey::Escape)
                             && let Some(on_close) = key_close.as_ref()

--- a/packages/oneclient_app/src/components/recents_row.rs
+++ b/packages/oneclient_app/src/components/recents_row.rs
@@ -293,9 +293,6 @@ impl Component for OtherVersionsTile {
     }
 }
 
-/// `n` cards occupy `n` gaps (n-1 between cards one before the tile) so `n * (MIN + GAP) + MORE`
-/// must fit
-/// Always returns at least 1 the card carries no `min_width` and just renders narrower
 fn recent_card_slots_for_width(row_width_px: f32) -> usize {
     if !row_width_px.is_finite() {
         return 1;

--- a/packages/oneclient_app/src/components/screenshot_viewer.rs
+++ b/packages/oneclient_app/src/components/screenshot_viewer.rs
@@ -1,7 +1,7 @@
 use freya::prelude::*;
 use oneclient_core::ScreenshotInfo;
 
-use crate::components::{Button, Icon, IconType, LocalImage, OverlayPopup};
+use crate::components::{Button, ContextMenu, Icon, IconType, LocalImage, OverlayPopup};
 use crate::hooks::{ScreenshotAction, use_dispatch, use_screenshot_action};
 use crate::theme::colors;
 use crate::ui::fmt_date;
@@ -37,6 +37,7 @@ impl Component for ScreenshotViewer {
             let start = self.start.min(len.saturating_sub(1));
             move || start
         });
+        let mut menu = use_state(|| None::<(f32, f32)>);
 
         if len == 0 {
             return rect().into_element();
@@ -50,6 +51,7 @@ impl Component for ScreenshotViewer {
         let close = self.on_close.clone();
         let scrim_close = self.on_close.clone();
         let delete_close = self.on_close.clone();
+        let menu_delete_close = self.on_close.clone();
 
         let has_prev = idx > 0;
         let has_next = idx + 1 < len;
@@ -60,6 +62,41 @@ impl Component for ScreenshotViewer {
         let copy_path = info.path.clone();
         let copy_dispatch = dispatch.clone();
         let delete_path = info.path.clone();
+
+        let menu_overlay = (*menu.read()).map(|(x, y)| {
+            let open_path = info.path.clone();
+            let copy_path = info.path.clone();
+            let copy_dispatch = dispatch.clone();
+            let delete_path = info.path.clone();
+            let delete_close = menu_delete_close.clone();
+
+            // Nested inside this viewer's popup, so it has to be raised above it
+            ContextMenu::new(x, y)
+                .overlay_level(16)
+                .on_close(move |_| menu.set(None))
+                .action(IconType::Folder, "Open in folder", move |()| {
+                    if let Some(dir) = open_path.parent() {
+                        crate::platform::open_url(&dir.to_string_lossy());
+                    }
+                })
+                .action(IconType::Copy01, "Copy", move |()| {
+                    crate::platform::copy_image_to_clipboard(copy_path.clone());
+                    copy_dispatch
+                        .notify("Copied to clipboard")
+                        .body("Screenshot copied to your clipboard.")
+                        .info()
+                        .icon(IconType::ClipboardCheck)
+                        .send();
+                })
+                .separator()
+                .danger_action(IconType::Trash01, "Delete", move |()| {
+                    action.mutate(ScreenshotAction::Delete {
+                        path: delete_path.clone(),
+                    });
+                    delete_close.call(());
+                })
+                .into_element()
+        });
 
         OverlayPopup::new()
             .on_close(move |_| scrim_close.call(()))
@@ -100,6 +137,14 @@ impl Component for ScreenshotViewer {
                                         rect()
                                             .width(Size::flex(1.0))
                                             .height(Size::fill())
+                                            .on_secondary_down(move |e: Event<PressEventData>| {
+                                                if let PressEventData::Mouse(m) = e.data() {
+                                                    menu.set(Some((
+                                                        m.global_location.x as f32,
+                                                        m.global_location.y as f32,
+                                                    )));
+                                                }
+                                            })
                                             .child(preview),
                                     )
                                     .child(chevron_btn(
@@ -163,6 +208,7 @@ impl Component for ScreenshotViewer {
                             ),
                     ),
             )
+            .maybe_child(menu_overlay)
             .into_element()
     }
 }


### PR DESCRIPTION
## Description

Added context menu on rmb inside screenshot viewer, it has the same buttons as the buttons on the bottom of the viewer

WARNING:
firstly the issue ( https://github.com/Polyfrost/OneLauncher/issues/566 ) has to be merged into the main before merging this branch. Most likely there are going to be problems with these two, but the 566 issue is more important, so after merging 566 this one can me merged and the context menu inside the ss viewer has to be tweaked.

## Related Issue(s)

https://github.com/Polyfrost/OneLauncher/issues/638

## How to test

1. Go to the screenshot viewer inside a cluster
2. Click on a screenshot
3. Right click on the image

## Documentation

No
