### PR TITLE
fix: fixed 404 response from curseforge

### DIFF
--- a/packages/oneclient_content/src/packages/provider/curseforge.rs
+++ b/packages/oneclient_content/src/packages/provider/curseforge.rs
@@ -210,17 +210,17 @@ impl PackageProvider for CurseForgeProvider {
         Ok(response.data.into_iter().map(|c| c.name).collect())
     }
 
-    #[tracing::instrument(level = "debug", skip(self, _project_id, ctx))]
+    #[tracing::instrument(level = "debug", skip(self, ctx))]
     async fn get_version(
         &self,
-        _project_id: &str,
+        project_id: &str,
         version_id: &str,
         ctx: &ContentCtx,
     ) -> ContentResult<VersionDetail> {
         let response: CfData<CfFile> = fetch_json(
             &ctx.net,
             Method::GET,
-            &api_url(&format!("/mods/files/{version_id}")),
+            &api_url(&format!("/mods/{project_id}/files/{version_id}")),
             None,
         )
         .await?;


### PR DESCRIPTION
## Description

Fixed 404 response from curseforge while trying to install mods from it
(There was a wrong request url)

## Related Issue(s)

https://github.com/Polyfrost/OneLauncher/issues/570

## How to test

1. Try installing curseforge mod from mod browser
- now it doesn't return 404 response

## Documentation

No
