### PR TITLE
fix: fixed hidden mods being enabled on every launch

### DIFF
--- a/.sqlx/query-e372eec993f6e82238fe95b1c74dbb377ee08e44c7e8c3b5eaa6f3b8b229fddf.json
+++ b/.sqlx/query-e372eec993f6e82238fe95b1c74dbb377ee08e44c7e8c3b5eaa6f3b8b229fddf.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "SQLite",
+  "query": "\n\t\tSELECT cluster_id, hash, cluster_file_name, enabled\n\t\tFROM cluster_artifacts\n\t\tWHERE cluster_id = ?\n\t\t",
+  "describe": {
+    "columns": [
+      {
+        "name": "cluster_id",
+        "ordinal": 0,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "cluster_artifacts",
+            "name": "cluster_id"
+          }
+        }
+      },
+      {
+        "name": "hash",
+        "ordinal": 1,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "cluster_artifacts",
+            "name": "hash"
+          }
+        }
+      },
+      {
+        "name": "cluster_file_name",
+        "ordinal": 2,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "cluster_artifacts",
+            "name": "cluster_file_name"
+          }
+        }
+      },
+      {
+        "name": "enabled",
+        "ordinal": 3,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "cluster_artifacts",
+            "name": "enabled"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e372eec993f6e82238fe95b1c74dbb377ee08e44c7e8c3b5eaa6f3b8b229fddf"
+}

--- a/packages/oneclient_content/src/bundles/install.rs
+++ b/packages/oneclient_content/src/bundles/install.rs
@@ -194,12 +194,9 @@ pub async fn install_bundle(
 
 /// `suppression` comes from [`find_user_suppression`] so a choice filed under a
 /// bundle the file has since left still counts
-pub(crate) fn disable_was_deliberate(hidden: bool, suppression: Option<OverrideType>) -> bool {
+pub(crate) fn disable_was_deliberate(suppression: Option<OverrideType>) -> bool {
     match suppression {
-        Some(OverrideType::Removed) => true,
-        // Hidden files are never-shown dependencies
-        // they follow the bundle so only an outright removal keeps one off
-        Some(OverrideType::Disabled) => !hidden,
+        Some(OverrideType::Removed | OverrideType::Disabled) => true,
         Some(OverrideType::Enabled) | None => false,
     }
 }
@@ -243,7 +240,7 @@ pub async fn heal_bundle_activity(
         // a package that moved keeps its old override row and reading only its
         // current bundle would switch it back on
         let suppression = find_user_suppression(&overrides, package_id);
-        if disable_was_deliberate(is_hidden, suppression) {
+        if disable_was_deliberate(suppression) {
             continue;
         }
 
@@ -803,32 +800,32 @@ mod tests {
 
     #[test]
     fn a_disable_with_no_override_behind_it_is_an_accident() {
-        assert!(!disable_was_deliberate(false, None));
-        assert!(!disable_was_deliberate(true, None));
+        assert!(!disable_was_deliberate(None));
     }
 
     #[test]
     fn a_users_own_disable_is_respected() {
-        assert!(disable_was_deliberate(
-            false,
-            Some(OverrideType::Disabled)
-        ));
-        assert!(disable_was_deliberate(false, Some(OverrideType::Removed)));
+        assert!(disable_was_deliberate(Some(OverrideType::Disabled)));
+        assert!(disable_was_deliberate(Some(OverrideType::Removed)));
     }
 
     #[test]
-    fn a_hidden_dependency_cannot_be_disabled_on_its_own() {
+    fn a_hidden_dependency_can_be_disabled_on_its_own() {
+        let file = BundleFile {
+            hidden: true,
+            ..file(true)
+        };
+
         assert!(
-            !disable_was_deliberate(true, Some(OverrideType::Disabled)),
-            "a hidden file follows its bundle; only removing it keeps it off"
+            disable_was_deliberate(Some(OverrideType::Disabled)),
+            "the hidden filter offers the toggle so the choice behind it has to outlive a launch"
         );
-        assert!(disable_was_deliberate(true, Some(OverrideType::Removed)));
+        assert!(!effective_enabled(&file, Some(OverrideType::Disabled)));
     }
 
     #[test]
     fn an_opt_in_override_never_reads_as_a_disable() {
-        assert!(!disable_was_deliberate(false, Some(OverrideType::Enabled)));
-        assert!(!disable_was_deliberate(true, Some(OverrideType::Enabled)));
+        assert!(!disable_was_deliberate(Some(OverrideType::Enabled)));
     }
 
     #[test]

--- a/packages/oneclient_content/src/bundles/updates.rs
+++ b/packages/oneclient_content/src/bundles/updates.rs
@@ -577,7 +577,7 @@ async fn reconcile_update(
 ) -> ContentResult<()> {
     let file_id = update.new_file.kind.package_id();
     let suppression = find_user_suppression(overrides, &file_id);
-    let enabled = !disable_was_deliberate(update.new_file.hidden, suppression);
+    let enabled = !disable_was_deliberate(suppression);
     set_artifact_enabled_to(update.cluster_id, hash, enabled, ctx).await?;
 
     if hash == update.installed_hash {
@@ -596,7 +596,7 @@ async fn reconcile_addition(
 ) -> ContentResult<()> {
     let file_id = addition.new_file.kind.package_id();
     let suppression = find_user_suppression(overrides, &file_id);
-    let enabled = !disable_was_deliberate(addition.new_file.hidden, suppression);
+    let enabled = !disable_was_deliberate(suppression);
     set_artifact_enabled_to(addition.cluster_id, hash, enabled, ctx).await
 }
 


### PR DESCRIPTION
## Description

Fixed hidden mods getting enabled even when user disabled them

## Related Issue(s)

## How to test

1. Disable a hidden mod
2. Launch the game
3. Check live log if the given mod is present

## Documentation

No