### PR TITLE
fix: fixed cluster settings not inheriting value from global memory

### DIFF
--- a/packages/oneclient_app/src/components/memory_field.rs
+++ b/packages/oneclient_app/src/components/memory_field.rs
@@ -4,14 +4,17 @@ use crate::components::{Dropdown, TextInput, validate_memory};
 use crate::theme::colors;
 use crate::utils::{format_memory_gb, memory_presets_mb};
 
-const UNSET_LABEL: &str = "Default";
 const CUSTOM_LABEL: &str = "Custom";
 
 /// Presets picker with an input for memory allocation
-pub fn memory_field(mut memory: State<String>) -> impl IntoElement {
+pub fn memory_field(
+    mut memory: State<String>,
+    unset_label: &str,
+    placeholder: u32,
+) -> impl IntoElement {
     let presets = memory_presets_mb();
     let selected = match memory.read().trim() {
-        "" => UNSET_LABEL.to_string(),
+        "" => unset_label.to_string(),
         value => value
             .parse::<u32>()
             .ok()
@@ -20,7 +23,8 @@ pub fn memory_field(mut memory: State<String>) -> impl IntoElement {
             .unwrap_or_else(|| CUSTOM_LABEL.to_string()),
     };
 
-    let options: Vec<String> = presets.iter().copied().map(format_memory_gb).collect();
+    let mut options: Vec<String> = vec![unset_label.to_string()];
+    options.extend(presets.iter().copied().map(format_memory_gb));
 
     rect()
         .horizontal()
@@ -31,7 +35,9 @@ pub fn memory_field(mut memory: State<String>) -> impl IntoElement {
                 .width(Size::px(100.))
                 .height(Size::px(34.))
                 .on_select(move |idx: usize| {
-                    if let Some(mb) = presets.get(idx).copied() {
+                    if idx == 0 {
+                        memory.set(String::new());
+                    } else if let Some(mb) = presets.get(idx - 1).copied() {
                         memory.set(mb.to_string());
                     }
                 }),
@@ -39,7 +45,7 @@ pub fn memory_field(mut memory: State<String>) -> impl IntoElement {
         .child(
             TextInput::new(memory)
                 .width(Size::px(90.))
-                .placeholder(oneclient_common::default_mem_max().to_string())
+                .placeholder(placeholder.to_string())
                 .on_validate(validate_memory)
                 .trailing(
                     label()

--- a/packages/oneclient_app/src/view/app/cluster/cluster_settings.rs
+++ b/packages/oneclient_app/src/view/app/cluster/cluster_settings.rs
@@ -357,8 +357,8 @@ impl Component for MemoryRow {
         let overridden = self.value.is_some();
         let dispatch = use_dispatch();
 
-        let global = self.global.to_string();
-        let initial = self.value.unwrap_or(self.global).to_string();
+        let global = self.global;
+        let initial = self.value.map(|v| v.to_string()).unwrap_or_default();
         let mut memory = use_state({
             let v = initial.clone();
             move || v
@@ -387,13 +387,13 @@ impl Component for MemoryRow {
         }
 
         let on_reset: EventHandler<()> = (move |()| {
-            last.set(global.clone());
-            memory.set(global.clone());
+            last.set(String::new());
+            memory.set(String::new());
             dispatch.update_cluster_profile(cluster_id, clear_update(Field::MemMax));
         })
         .into();
 
-        let control = memory_field(memory);
+        let control = memory_field(memory, "Global", global);
 
         settings_row(
             IconType::Database01,

--- a/packages/oneclient_app/src/view/app/settings/minecraft.rs
+++ b/packages/oneclient_app/src/view/app/settings/minecraft.rs
@@ -105,7 +105,7 @@ impl Component for SettingsMinecraft {
                 IconType::Database01,
                 "Memory",
                 "The amount of memory in megabytes allocated for the game. Presets leave 2 GB for the system.",
-                memory_field(memory),
+                memory_field(memory, "Default", oneclient_common::default_mem_max()),
             ))
             .child(settings_row(
                 IconType::Terminal,

--- a/packages/oneclient_cluster/src/profiles.rs
+++ b/packages/oneclient_cluster/src/profiles.rs
@@ -76,9 +76,7 @@ pub async fn create_profile_from_global(
     let mut profile = global.clone();
 
     profile.name = name.to_string();
-    if let Some(mem) = mem_max {
-        profile.mem_max = Some(mem);
-    }
+    profile.mem_max = mem_max;
 
     if let Some(fullscreen) = force_fullscreen {
         profile.force_fullscreen = Some(fullscreen);


### PR DESCRIPTION
## Description

Added a Global value for memory field that inherits memory value from minecraft settings.

## Related Issue(s)

## How to test

1. Go to cluster settings, click refresh on memory field
2. It should say "Global"

## Documentation

No
